### PR TITLE
Fixed badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ limitations under the License.
 [travis]: https://travis-ci.org/snowplow/snowplow-java-tracker
 [travis-image]: https://travis-ci.org/snowplow/snowplow-java-tracker.svg?branch=master
 
-[release-image]: http://img.shields.io/badge/release-0.7.0-blue.svg?style=flat
+[release-image]: https://img.shields.io/github/release/snowplow/snowplow-java-tracker.svg?style=flat
 [releases]: https://github.com/snowplow/snowplow-java-tracker/releases
 
 [license-image]: http://img.shields.io/badge/license-Apache--2-blue.svg?style=flat


### PR DESCRIPTION
Removes the hard coded badge link to follow the repo release instead.