### PR TITLE
Separated timestamp in 'true timestamp' and 'device created timestamp'

### DIFF
--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -274,7 +274,8 @@ public class Tracker {
             this.track(Unstructured.builder()
                     .eventData((SelfDescribingJson) event.getPayload())
                     .customContext(context)
-                    .timestamp(event.getTimestamp())
+                    .deviceCreatedTimestamp(event.getDeviceCreatedTimestamp())
+                    .trueTimestamp(event.getTrueTimestamp())
                     .eventId(event.getEventId())
                     .subject(subject)
                     .build());

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/constants/Constants.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/constants/Constants.java
@@ -20,7 +20,7 @@ public class Constants {
     public static final String PROTOCOL_VENDOR = "com.snowplowanalytics.snowplow";
     public static final String PROTOCOL_VERSION = "tp2";
 
-    public static final String SCHEMA_PAYLOAD_DATA = "iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-3";
+    public static final String SCHEMA_PAYLOAD_DATA = "iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4";
     public static final String SCHEMA_CONTEXTS = "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1";
     public static final String SCHEMA_UNSTRUCT_EVENT = "iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0";
     public static final String SCHEMA_SCREEN_VIEW = "iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0";

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/constants/Parameter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/constants/Parameter.java
@@ -19,7 +19,14 @@ public class Parameter {
     public static final String DATA = "data";
     public static final String EVENT = "e";
     public static final String EID = "eid";
-    public static final String TIMESTAMP = "dtm";
+
+    public static final String TRUE_TIMESTAMP = "ttm";
+
+    public static final String DEVICE_CREATED_TIMESTAMP = "dtm";
+
+    /** deprecated Indicate the specific timestamp to use. This is kept for compatibility with older versions. */
+    @Deprecated
+    public static final String TIMESTAMP = DEVICE_CREATED_TIMESTAMP;
     public static final String TRACKER_VERSION = "tv";
     public static final String APP_ID = "aid";
     public static final String NAMESPACE = "tna";

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransactionItem.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransactionItem.java
@@ -13,6 +13,7 @@
 package com.snowplowanalytics.snowplow.tracker.events;
 
 // Google
+
 import com.google.common.base.Preconditions;
 
 // This library
@@ -141,9 +142,25 @@ public class EcommerceTransactionItem extends AbstractEvent {
 
     /**
      * @param timestamp the new timestamp
+     * @deprecated Use {@link #setTrueTimestamp(long)} or {@link #setTrueTimestamp(long)}
      */
+    @Deprecated
     public void setTimestamp(long timestamp) {
-        this.timestamp = timestamp;
+        setDeviceCreatedTimestamp(timestamp);
+    }
+
+    /**
+     * @param timestamp the new timestamp
+     */
+    public void setTrueTimestamp(long timestamp) {
+        this.trueTimestamp = timestamp;
+    }
+
+    /**
+     * @param timestamp the new timestamp
+     */
+    public void setDeviceCreatedTimestamp(Long timestamp) {
+        this.deviceCreatedTimestamp = timestamp;
     }
 
     /**

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Event.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Event.java
@@ -31,9 +31,21 @@ public interface Event {
     List<SelfDescribingJson> getContext();
 
     /**
-     * @return the events timestamp
+     * @return the event's timestamp
+     * @Deprecated Use {@link #getTrueTimestamp()} or {@link #getDeviceCreatedTimestamp()}
      */
+    @Deprecated
     long getTimestamp();
+
+    /**
+     * @return the event's true timestamp
+     */
+    Long getTrueTimestamp();
+
+    /**
+     * @return the event's device created timestamp
+     */
+    long getDeviceCreatedTimestamp();
 
     /**
      * @return the event id

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -78,7 +78,8 @@ public class TrackerTest {
                 .category("category")
                 .currency("currency")
                 .customContext(contexts)
-                .timestamp(123456)
+                .deviceCreatedTimestamp(123456)
+                .trueTimestamp(456789L)
                 .eventId(EXPECTED_EVENT_ID)
                 .build();
 
@@ -95,7 +96,8 @@ public class TrackerTest {
                 .currency("currency")
                 .items(item)
                 .customContext(contexts)
-                .timestamp(123456)
+                .deviceCreatedTimestamp(123456)
+                .trueTimestamp(456789L)
                 .eventId(EXPECTED_EVENT_ID)
                 .build());
 
@@ -113,6 +115,7 @@ public class TrackerTest {
                 .put("aid", "cloudfront")
                 .put("tr_sh", "3.0")
                 .put("dtm", "123456")
+                .put("ttm", "456789")
                 .put("tz", "Etc/UTC")
                 .put("tr_co", "country")
                 .put("tv", Version.TRACKER)
@@ -136,6 +139,7 @@ public class TrackerTest {
                 .put("aid", "cloudfront")
                 .put("ti_cu", "currency")
                 .put("dtm", "123456")
+                .put("ttm", "456789")
                 .put("tz", "Etc/UTC")
                 .put("ti_pr", "1.0")
                 .put("ti_qu", "2")
@@ -155,7 +159,8 @@ public class TrackerTest {
                         ImmutableMap.of("foo", "bar")
                 ))
                 .customContext(contexts)
-                .timestamp(123456)
+                .deviceCreatedTimestamp(123456)
+                .trueTimestamp(456789L)
                 .eventId(EXPECTED_EVENT_ID)
                 .build());
 
@@ -173,6 +178,7 @@ public class TrackerTest {
                 .put("tz", "Etc/UTC")
                 .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"payload\",\"data\":{\"foo\":\"bar\"}}}")
                 .put("dtm", "123456")
+                .put("ttm", "456789")
                 .put("aid", "cloudfront")
                 .build(), result);
     }
@@ -185,7 +191,37 @@ public class TrackerTest {
                         "payload",
                         ImmutableMap.of("foo", "baær")
                 ))
-                .timestamp(123456)
+                .deviceCreatedTimestamp(123456)
+                .trueTimestamp(456789L)
+                .eventId(EXPECTED_EVENT_ID)
+                .build());
+
+        // Then
+        verify(emitter).emit(captor.capture());
+        Map result = captor.getValue().getMap();
+        assertEquals(ImmutableMap.<String, String>builder()
+                .put("p", "srv")
+                .put("tv", Version.TRACKER)
+                .put("eid", EXPECTED_EVENT_ID)
+                .put("e", "ue")
+                .put("tna", "AF003")
+                .put("tz", "Etc/UTC")
+                .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"payload\",\"data\":{\"foo\":\"baær\"}}}")
+                .put("dtm", "123456")
+                .put("ttm", "456789")
+                .put("aid", "cloudfront")
+                .build(), result);
+    }
+
+    @Test
+    public void testUnstructuredEventWithoutTrueTimestamp() {
+        // When
+        tracker.track(Unstructured.builder()
+                .eventData(new SelfDescribingJson(
+                        "payload",
+                        ImmutableMap.of("foo", "baær")
+                ))
+                .deviceCreatedTimestamp(123456)
                 .eventId(EXPECTED_EVENT_ID)
                 .build());
 
@@ -213,7 +249,8 @@ public class TrackerTest {
                 .pageTitle("title")
                 .referrer("referer")
                 .customContext(contexts)
-                .timestamp(123456)
+                .deviceCreatedTimestamp(123456)
+                .trueTimestamp(456789L)
                 .eventId(EXPECTED_EVENT_ID)
                 .build());
 
@@ -222,6 +259,7 @@ public class TrackerTest {
         Map result = captor.getValue().getMap();
         assertEquals(ImmutableMap.<String, String>builder()
                 .put("dtm", "123456")
+                .put("ttm", "456789")
                 .put("tz", "Etc/UTC")
                 .put("e", "pv")
                 .put("page", "title")
@@ -243,7 +281,8 @@ public class TrackerTest {
                 .name("name")
                 .id("id")
                 .customContext(contexts)
-                .timestamp(123456)
+                .deviceCreatedTimestamp(123456)
+                .trueTimestamp(456789L)
                 .eventId(EXPECTED_EVENT_ID)
                 .build());
 
@@ -252,6 +291,7 @@ public class TrackerTest {
         Map result = captor.getValue().getMap();
         assertEquals(ImmutableMap.<String, String>builder()
                 .put("dtm", "123456")
+                .put("ttm", "456789")
                 .put("tz", "Etc/UTC")
                 .put("e", "ue")
                 .put("tv", Version.TRACKER)
@@ -270,7 +310,8 @@ public class TrackerTest {
         tracker.track(ScreenView.builder()
                 .name("name")
                 .id("id")
-                .timestamp(123456)
+                .deviceCreatedTimestamp(123456)
+                .trueTimestamp(456789L)
                 .eventId(EXPECTED_EVENT_ID)
                 .build());
 
@@ -279,6 +320,7 @@ public class TrackerTest {
         Map result = captor.getValue().getMap();
         assertEquals(ImmutableMap.<String, String>builder()
                 .put("dtm", "123456")
+                .put("ttm", "456789")
                 .put("tz", "Etc/UTC")
                 .put("e", "ue")
                 .put("tv", Version.TRACKER)
@@ -297,7 +339,8 @@ public class TrackerTest {
                 .name("name")
                 .id("id")
                 .customContext(contexts)
-                .timestamp(123456)
+                .deviceCreatedTimestamp(123456)
+                .trueTimestamp(456789L)
                 .eventId(EXPECTED_EVENT_ID)
                 .build());
 
@@ -314,6 +357,7 @@ public class TrackerTest {
                 .put("tz", "Etc/UTC")
                 .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0\",\"data\":{\"id\":\"id\",\"name\":\"name\"}}}")
                 .put("dtm", "123456")
+                .put("ttm", "456789")
                 .put("aid", "cloudfront")
                 .build(), result);
     }
@@ -327,7 +371,8 @@ public class TrackerTest {
                 .variable("variable")
                 .timing(10)
                 .customContext(contexts)
-                .timestamp(123456)
+                .deviceCreatedTimestamp(123456)
+                .trueTimestamp(456789L)
                 .eventId(EXPECTED_EVENT_ID)
                 .build());
 
@@ -344,6 +389,7 @@ public class TrackerTest {
                 .put("tz", "Etc/UTC")
                 .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:com.snowplowanalytics.snowplow/timing/jsonschema/1-0-0\",\"data\":{\"category\":\"category\",\"label\":\"label\",\"timing\":10,\"variable\":\"variable\"}}}")
                 .put("dtm", "123456")
+                .put("ttm", "456789")
                 .put("aid", "cloudfront")
                 .build(), result);
     }
@@ -362,7 +408,8 @@ public class TrackerTest {
                 .variable("variable")
                 .timing(10)
                 .customContext(contexts)
-                .timestamp(123456)
+                .deviceCreatedTimestamp(123456)
+                .trueTimestamp(456789L)
                 .eventId(EXPECTED_EVENT_ID)
                 .subject(s1)
                 .build());
@@ -381,6 +428,7 @@ public class TrackerTest {
                 .put("tna", "AF003")
                 .put("tz", "Etc/UTC")
                 .put("dtm", "123456")
+                .put("ttm", "456789")
                 .put("aid", "cloudfront")
                 .build(), result);
     }


### PR DESCRIPTION
Tests were OK before I modified them (because I kept the old version as deprecated), OK now with the new methods.
