### PR TITLE
Allow Payload to cary non-string values as allowed by jsonschema (…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ apply plugin: 'propdeps-maven'
 apply plugin: 'propdeps-idea'
 
 group = 'com.snowplowanalytics'
-version = '0.8.2'
+version = '0.8.3-SNAPSHOT'
 sourceCompatibility = '1.7'
 targetCompatibility = '1.7'
 
@@ -116,7 +116,7 @@ task generateSources {
         srcFile.parentFile.mkdirs()
         srcFile.write(
                 """/*
- * Copyright (c) 2014-2015 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2014-2016 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -306,9 +306,9 @@ public class Tracker {
 
         // Add subject if available
         if (eventSubject != null) {
-            payload.addMap(new HashMap<>(eventSubject.getSubject()));
+            payload.addMap(new HashMap<String,Object>(eventSubject.getSubject()));
         } else if (this.subject != null) {
-            payload.addMap(new HashMap<>(this.subject.getSubject()));
+            payload.addMap(new HashMap<String,Object>(this.subject.getSubject()));
         }
 
         // Send the event!

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/Payload.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/Payload.java
@@ -29,7 +29,7 @@ public interface Payload {
      * @param key The parameter key
      * @param value The parameter value as a String
      */
-    void add(String key, String value);
+    void add(String key, Object value);
 
     /**
      * Add all the mappings from the specified map. The effect is the equivalent to that of calling:
@@ -37,7 +37,7 @@ public interface Payload {
      *
      * @param map Key-Value pairs to be stored in this payload
      */
-    void addMap(Map<String, String> map);
+    void addMap(Map<String, Object> map);
 
     /**
      * Add a map to the Payload with a key dependent on the base 64 encoding option you choose using the

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/SelfDescribingJson.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/SelfDescribingJson.java
@@ -141,13 +141,13 @@ public class SelfDescribingJson implements Payload {
 
     @Deprecated
     @Override
-    public void add(String key, String value) {
+    public void add(String key, Object value) {
         LOGGER.info("Payload: add(String, String) method called - Doing nothing.");
     }
 
     @Deprecated
     @Override
-    public void addMap(Map<String, String> map) {
+    public void addMap(Map<String, Object> map) {
         LOGGER.info("Payload: addMap(Map<String, Object>) method called - Doing nothing.");
     }
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayload.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayload.java
@@ -30,7 +30,7 @@ import com.snowplowanalytics.snowplow.tracker.Utils;
 public class TrackerPayload implements Payload {
 
     private final Logger LOGGER = LoggerFactory.getLogger(TrackerPayload.class);
-    private final LinkedHashMap<String, String> payload = new LinkedHashMap<>();
+    private final LinkedHashMap<String, Object> payload = new LinkedHashMap<>();
 
     /**
      * Add a key-value pair to the payload:
@@ -41,8 +41,8 @@ public class TrackerPayload implements Payload {
      * @param value The parameter value as a String
      */
     @Override
-    public void add(String key, String value) {
-        if (key == null || key.isEmpty() || value == null || value.isEmpty()) {
+    public void add(String key, Object value) {
+        if (key == null || key.isEmpty() || value == null ) {
             LOGGER.error("Invalid kv pair detected: {}->{}", key, value);
             return;
         }
@@ -57,13 +57,13 @@ public class TrackerPayload implements Payload {
      * @param map Key-Value pairs to be stored in this payload
      */
     @Override
-    public void addMap(Map<String, String> map) {
+    public void addMap(Map<String, Object> map) {
         if (map == null) {
             LOGGER.debug("Map passed in is null, returning without adding map.");
             return;
         }
         LOGGER.info("Adding new map: {}", map);
-        for (Map.Entry<String, String> entry : map.entrySet()) {
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
             add(entry.getKey(), entry.getValue());
         }
     }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayload.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayload.java
@@ -42,7 +42,7 @@ public class TrackerPayload implements Payload {
      */
     @Override
     public void add(String key, Object value) {
-        if (key == null || key.isEmpty() || value == null ) {
+        if (key == null || key.isEmpty() || value == null || (value instanceof String && ((String) value).isEmpty())) {
             LOGGER.error("Invalid kv pair detected: {}->{}", key, value);
             return;
         }

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -390,7 +390,7 @@ public class TrackerTest {
     @Test
     public void testGetTrackerVersion() throws Exception {
         Tracker tracker = new Tracker.TrackerBuilder(emitter, "namespace", "an-app-id").build();
-        assertEquals("java-0.8.2", tracker.getTrackerVersion());
+        assertEquals("java-0.8.3-SNAPSHOT", tracker.getTrackerVersion());
     }
 
     @Test

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayloadTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayloadTest.java
@@ -51,7 +51,7 @@ public class TrackerPayloadTest {
 
     @Test
     public void testAddMap() {
-        Map<String, String> data = new HashMap<>();
+        Map<String, Object> data = new HashMap<>();
         data.put("key", "value");
         TrackerPayload payload = new TrackerPayload();
         payload.addMap(data);
@@ -62,7 +62,7 @@ public class TrackerPayloadTest {
 
     @Test
     public void testAddMapWithNullValue() {
-        Map<String, String> data = new HashMap<>();
+        Map<String, Object> data = new HashMap<>();
         data.put("key", null);
         TrackerPayload payload = new TrackerPayload();
         payload.addMap(data);
@@ -72,7 +72,7 @@ public class TrackerPayloadTest {
 
     @Test
     public void testAddMapWithEmptyValue() {
-        Map<String, String> data = new HashMap<>();
+        Map<String, Object> data = new HashMap<>();
         data.put("key", "");
         TrackerPayload payload = new TrackerPayload();
         payload.addMap(data);


### PR DESCRIPTION
…integer, numeric, boolean)

Current 0.8.2 version prevents java clients from firing events conforming to self describing schemas that contain non-string object property types. Example below illustrates a valid schema with a counter property of integer type. 

```
{
        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
        "description": "Example Event schema with non-string  object property type",
        "self": {
                "vendor": "com.example",
                "name": "exampleEvent",
                "format": "jsonschema",
                "version": "1-0-0"
        },
        "type": "object",
        "properties": {
                "counter": {
                        "type": "integer",
                        "minimum": 0
                }

        },
        "required": ["counter"],
        "additionalProperties": false
}
```