### PR TITLE
Change `slf4j-simple` to a test runtime dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,8 @@ dependencies {
     optional 'com.squareup.okhttp:okhttp:2.2.0'
     
     // SLF4J logging API
-    compile 'org.slf4j:slf4j-simple:1.7.7'
+    compile 'org.slf4j:slf4j-api:1.7.7'
+    runtime 'org.slf4j:slf4j-simple:1.7.7'
 
     // Jackson JSON processor
     compile 'com.fasterxml.jackson.core:jackson-databind:2.4.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     
     // SLF4J logging API
     compile 'org.slf4j:slf4j-api:1.7.7'
-    runtime 'org.slf4j:slf4j-simple:1.7.7'
+    testRuntime 'org.slf4j:slf4j-simple:1.7.7'
 
     // Jackson JSON processor
     compile 'com.fasterxml.jackson.core:jackson-databind:2.4.1.1'


### PR DESCRIPTION
- Add compile dependency on `slf4j-api`.
- Change `slf4j-simple` to only a test runtime one.

This should resolve https://github.com/snowplow/snowplow-java-tracker/issues/188