### PR TITLE
Specify the key for 'null or empty value detected' payload log (close #277)

### DIFF
--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayload.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayload.java
@@ -44,7 +44,7 @@ public class TrackerPayload implements Payload {
             return;
         }
         if (value == null || value.isEmpty()) {
-            LOGGER.info("null or empty value detected: {}", value);
+            LOGGER.info("null or empty value detected: {}->{}", key, value);
             return;
         }
         LOGGER.debug("Adding new kv pair: {}->{}", key, value);


### PR DESCRIPTION
There's no way to know which key is causing the "null or empty value detected" log, so this change makes this log possible to debug.