### PR TITLE
Update dependencies guava, wiremock, and httpclient (close #269)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,12 +77,11 @@ dependencies {
     api 'com.google.guava:guava:31.0-jre'
 
     // Testing libraries
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    testCompileOnly 'junit:junit:4.13'
-    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 
     testImplementation 'org.hamcrest:hamcrest:2.2'
-    testImplementation 'com.github.tomakehurst:wiremock:2.26.3'
+    testImplementation 'com.github.tomakehurst:wiremock-jre8:2.31.0'
     testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.7.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,6 @@ def javaVersion = JavaVersion.VERSION_1_8
 repositories {
     // Use 'maven central' for resolving our dependencies
     mavenCentral()
-    // Use 'jcenter' for resolving testing dependencies
-    jcenter()
 }
 
 configure([compileJava, compileTestJava]) {
@@ -76,7 +74,7 @@ dependencies {
     api 'com.fasterxml.jackson.core:jackson-databind:2.11.0'
 
     // Preconditions
-    api 'com.google.guava:guava:29.0-jre'
+    api 'com.google.guava:guava:31.0-jre'
 
     // Testing libraries
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     api 'commons-net:commons-net:3.6'
 
     // Apache HTTP
-    apachehttpSupportApi 'org.apache.httpcomponents:httpclient:4.5.12'
+    apachehttpSupportApi 'org.apache.httpcomponents:httpclient:4.5.13'
     apachehttpSupportApi 'org.apache.httpcomponents:httpasyncclient:4.1.4'
 
     // Square OK HTTP


### PR DESCRIPTION
For issue #269.

Guava 29.0 -> 31.0
HTTPClient 4.5.12 -> 4.5.13
Wiremock 2.26.3 -> 2.31.0

There was a problem with JUnit following the Wiremock upgrade. The 4.13 version is known to be faulty and was only being used for test compiling. That has been removed to use JUnit 5.8.1 consistently.