### PR TITLE
Manually set the session_id (close #265)

### DIFF
--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
@@ -295,7 +295,7 @@ public class Subject {
      * User inputted Domain Session ID for the
      * subject.
      *
-     * @param domainSessionId a domain user id
+     * @param domainSessionId a domain session id
      */
     public void setDomainSessionId(String domainSessionId) {
         if (domainSessionId != null) {

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
@@ -42,6 +42,7 @@ public class Subject {
         this.setUseragent(builder.useragent);
         this.setNetworkUserId(builder.networkUserId);
         this.setDomainUserId(builder.domainUserId);
+        this.setDomainSessionId(builder.domainSessionId);
     }
 
     /**
@@ -69,6 +70,7 @@ public class Subject {
         private String useragent; // Optional
         private String networkUserId; // Optional
         private String domainUserId; // Optional
+        private String domainSessionId; // Optional
 
         /**
          * @param userId a user id string
@@ -161,6 +163,15 @@ public class Subject {
          */
         public SubjectBuilder domainUserId(String domainUserId) {
             this.domainUserId = domainUserId;
+            return this;
+        }
+
+        /**
+         * @param domainSessionId a domainSessionId string
+         * @return itself
+         */
+        public SubjectBuilder domainSessionId(String domainSessionId) {
+            this.domainSessionId = domainSessionId;
             return this;
         }
 
@@ -277,6 +288,18 @@ public class Subject {
     public void setDomainUserId(String domainUserId) {
         if (domainUserId != null) {
             this.standardPairs.put(Parameter.DOMAIN_UID, domainUserId);
+        }
+    }
+
+    /**
+     * User inputted Domain Session ID for the
+     * subject.
+     *
+     * @param domainSessionId a domain user id
+     */
+    public void setDomainSessionId(String domainSessionId) {
+        if (domainSessionId != null) {
+            this.standardPairs.put(Parameter.SESSION_UID, domainSessionId);
         }
     }
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/constants/Parameter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/constants/Parameter.java
@@ -49,6 +49,7 @@ public class Parameter {
     public static final String USERAGENT = "ua";
     public static final String DOMAIN_UID = "duid";
     public static final String NETWORK_UID = "tnuid";
+    public static final String SESSION_UID = "sid";
 
     // Page View
     public static final String PAGE_URL = "url";

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
@@ -93,6 +93,13 @@ public class SubjectTest {
     }
 
     @Test
+    public void testSetSid() throws Exception {
+        Subject subject = new Subject.SubjectBuilder().build();
+        subject.setDomainSessionId("sessionid");
+        assertEquals("sessionid", subject.getSubject().get("sid"));
+    }
+
+    @Test
     public void testGetSubject() throws Exception {
         Subject subject = new Subject.SubjectBuilder().build();
         Map<String, String> expected = new HashMap<>();

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
@@ -79,21 +79,21 @@ public class SubjectTest {
     }
 
     @Test
-    public void testSetDuid() throws Exception {
+    public void testSetDomainUserId() throws Exception {
         Subject subject = new Subject.SubjectBuilder().build();
         subject.setDomainUserId("duid");
         assertEquals("duid", subject.getSubject().get("duid"));
     }
 
     @Test
-    public void testSetNuid() throws Exception {
+    public void testSetNetworkUserId() throws Exception {
         Subject subject = new Subject.SubjectBuilder().build();
         subject.setNetworkUserId("nuid");
         assertEquals("nuid", subject.getSubject().get("tnuid"));
     }
 
     @Test
-    public void testSetSid() throws Exception {
+    public void testSetDomainSessionId() throws Exception {
         Subject subject = new Subject.SubjectBuilder().build();
         subject.setDomainSessionId("sessionid");
         assertEquals("sessionid", subject.getSubject().get("sid"));


### PR DESCRIPTION
Adds a new Subject method similar to `setDomainUserId()`, allowing users to set the atomic event property `domain_sessionid` (`sid` in raw events).