### PR TITLE
Update gradle GH Action to include Java 17 (close #273)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,18 +4,23 @@ name: Build
 on: [ push ]
 
 jobs:
-  build:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
 
+  build:
+    needs: prepare
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        # build and test against LTS releases and latest GA
-        java: [ 8, 11, 13 ]
+        # build and test against LTS releases
+        java: [ 8, 11, 17 ]
 
     steps:
     - uses: actions/checkout@v2
-    - uses: gradle/wrapper-validation-action@v1
 
     - name: Set up JDK
       uses: actions/setup-java@v1


### PR DESCRIPTION
Replaced Java 13 with the newest LTS version, Java 17, in the build and test matrix.

Also moved the gradle wrapper validation action into its own job before build, rather than running it 3 times.