### PR TITLE
Update Deploy action to remove Bintray (close #283) 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SONA_PGP_SECRET }}
 
       - name: Release on GitHub
-        uses: softprops/action-gh-release@v0.1.12
+        uses: softprops/action-gh-release@v1
         with:
           name: Version ${{ steps.version.outputs.TRACKER_VERSION }}
           prerelease: ${{ contains(steps.version.outputs.TRACKER_VERSION, '-') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,49 +1,53 @@
-
 name: Deploy
 
 on:
   push:
     tags:
-    - '*.*.*'
-    
+      - '*.*.*'
+
 jobs:
   deploy:
 
     runs-on: ubuntu-latest
-
-    env:
-      BINTRAY_SNOWPLOW_MAVEN_USER: ${{ secrets.BINTRAY_SNOWPLOW_MAVEN_USER }}
-      BINTRAY_SNOWPLOW_MAVEN_API_KEY: ${{ secrets.BINTRAY_SNOWPLOW_MAVEN_API_KEY }}
-      SONA_USER: 'snowplow'
-      SONA_PASS: ${{ secrets.SONA_PASS }}
-
     steps:
-    - uses: actions/checkout@v2
-    - uses: gradle/wrapper-validation-action@v1
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Set up JDK
-      uses: actions/setup-java@v1
-      with:
-        java-version: 8
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
 
-    - name: Cache Gradle packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle
-    
-    - name: Get tag and tracker version information
-      id: version
-      run: |
-        echo ::set-output name=TAG_VERSION::${GITHUB_REF#refs/*/}
-        echo "##[set-output name=TRACKER_VERSION;]$(./gradlew -q printVersion)"
-    
-    - name: Fail if version mismatch
-      if: ${{ steps.version.outputs.TAG_VERSION != steps.version.outputs.TRACKER_VERSION }}
-      run: |
-        echo "Tag version (${{ steps.version.outputs.TAG_VERSION }}) doesn't match version in project (${{ steps.version.outputs.TRACKER_VERSION }})"
-        exit 1
-      
-    - name: Publish
-      run: ./gradlew bintrayUpload
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      - name: Build
+        run: ./gradlew build
+
+      - name: Get tag and tracker version information
+        id: version
+        run: |
+          echo ::set-output name=TAG_VERSION::${GITHUB_REF#refs/*/}
+          echo "##[set-output name=TRACKER_VERSION;]$(./gradlew -q printVersion)"
+
+      - name: Fail if version mismatch
+        if: ${{ steps.version.outputs.TAG_VERSION != steps.version.outputs.TRACKER_VERSION }}
+        run: |
+          echo "Tag version (${{ steps.version.outputs.TAG_VERSION }}) doesn't match version in project (${{ steps.version.outputs.TRACKER_VERSION }})"
+          exit 1
+
+      - name: Publish to Maven Central
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+        env:
+          SONA_USER: ${{ secrets.SONA_USER }}
+          SONA_PASS: ${{ secrets.SONA_PASS }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SONA_PGP_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SONA_PGP_SECRET }}
+
+      - name: Release on GitHub
+        uses: softprops/action-gh-release@v0.1.12
+        with:
+          name: Version ${{ steps.version.outputs.TRACKER_VERSION }}
+          prerelease: ${{ contains(steps.version.outputs.TRACKER_VERSION, '-') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,10 @@
  */
 
 plugins {
-    id 'com.jfrog.bintray' version '1.8.5'
     id 'java-library'
     id 'maven-publish'
+    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
+    id 'signing'
     id 'idea'
 }
 
@@ -22,14 +23,13 @@ wrapper.gradleVersion = '6.5.0'
 
 group = 'com.snowplowanalytics'
 archivesBaseName = 'snowplow-java-tracker'
-version = '0.10.1'
+version = '0.11.0-alpha.15'
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 
 def javaVersion = JavaVersion.VERSION_1_8
 
 repositories {
-    // Use 'maven central' for resolving our dependencies
     mavenCentral()
 }
 
@@ -193,49 +193,22 @@ publishing {
     }
 }
 
-// Workaround for upload of module.json file, remove when issue fixed https://github.com/bintray/gradle-bintray-plugin/issues/229
-bintrayUpload.doFirst {
-    publishing.publications.all { publication ->
-        def moduleFile = file("$buildDir/publications/$publication.name/module.json")
-        if (moduleFile.exists()) {
-            artifact(moduleFile) {
-                extension = "module"
-            }
+nexusPublishing {
+    repositories {
+        sonatype {
+            username = System.getenv('SONA_USER')
+            password = System.getenv('SONA_PASS')
         }
     }
 }
 
-bintray {
-    user = System.getenv('BINTRAY_SNOWPLOW_MAVEN_USER')
-    key = System.getenv('BINTRAY_SNOWPLOW_MAVEN_API_KEY')
-
-    publish = true
-
-    pkg {
-        repo = 'snowplow-maven'
-        name = 'snowplow-java-tracker'
-
-        group = 'com.snowplowanalytics'
-        userOrg = 'snowplow'
-
-        websiteUrl = 'https://github.com/snowplow/snowplow-java-tracker'
-        vcsUrl = 'https://github.com/snowplow/snowplow-java-tracker'
-        issueTrackerUrl = 'https://github.com/snowplow/snowplow-java-tracker/issues'
-
-        licenses = ['Apache-2.0']
-        publications = ['mavenJava']
-
-        version {
-            name = "$project.version"
-            gpg {
-                sign = true
-            }
-            mavenCentralSync {
-                sync = true
-                user = System.getenv('SONA_USER')
-                password = System.getenv('SONA_PASS')
-                close = '1'
-            }
-        }
+signing {
+    if (System.getenv('ORG_GRADLE_PROJECT_signingKey') && System.getenv('ORG_GRADLE_PROJECT_signingPassword')) {
+        println 'Found signing credentials. Signing...'
+        def signingKey = findProperty("signingKey")
+        def signingPassword = findProperty("signingPassword")
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign publishing.publications.mavenJava
+        println 'Used useInMemoryPgpKeys()'
     }
 }


### PR DESCRIPTION
For issue #283.

Removes the deprecated Bintray commands, and releases to Maven Central. This required a couple of gradle plugins. [Signing](https://docs.gradle.org/current/userguide/signing_plugin.html) is an official Gradle plugin for managing the PGP signing required for publication on Maven Central. The [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin) handles the publishing task as well as closing and releasing the app from staging.