### PR TITLE
Release/0.11.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,49 +1,53 @@
-
 name: Deploy
 
 on:
   push:
     tags:
-    - '*.*.*'
-    
+      - '*.*.*'
+
 jobs:
   deploy:
 
     runs-on: ubuntu-latest
-
-    env:
-      BINTRAY_SNOWPLOW_MAVEN_USER: ${{ secrets.BINTRAY_SNOWPLOW_MAVEN_USER }}
-      BINTRAY_SNOWPLOW_MAVEN_API_KEY: ${{ secrets.BINTRAY_SNOWPLOW_MAVEN_API_KEY }}
-      SONA_USER: 'snowplow'
-      SONA_PASS: ${{ secrets.SONA_PASS }}
-
     steps:
-    - uses: actions/checkout@v2
-    - uses: gradle/wrapper-validation-action@v1
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Set up JDK
-      uses: actions/setup-java@v1
-      with:
-        java-version: 8
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
 
-    - name: Cache Gradle packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle
-    
-    - name: Get tag and tracker version information
-      id: version
-      run: |
-        echo ::set-output name=TAG_VERSION::${GITHUB_REF#refs/*/}
-        echo "##[set-output name=TRACKER_VERSION;]$(./gradlew -q printVersion)"
-    
-    - name: Fail if version mismatch
-      if: ${{ steps.version.outputs.TAG_VERSION != steps.version.outputs.TRACKER_VERSION }}
-      run: |
-        echo "Tag version (${{ steps.version.outputs.TAG_VERSION }}) doesn't match version in project (${{ steps.version.outputs.TRACKER_VERSION }})"
-        exit 1
-      
-    - name: Publish
-      run: ./gradlew bintrayUpload
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      - name: Build
+        run: ./gradlew build
+
+      - name: Get tag and tracker version information
+        id: version
+        run: |
+          echo ::set-output name=TAG_VERSION::${GITHUB_REF#refs/*/}
+          echo "##[set-output name=TRACKER_VERSION;]$(./gradlew -q printVersion)"
+
+      - name: Fail if version mismatch
+        if: ${{ steps.version.outputs.TAG_VERSION != steps.version.outputs.TRACKER_VERSION }}
+        run: |
+          echo "Tag version (${{ steps.version.outputs.TAG_VERSION }}) doesn't match version in project (${{ steps.version.outputs.TRACKER_VERSION }})"
+          exit 1
+
+      - name: Publish to Maven Central
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+        env:
+          SONA_USER: ${{ secrets.SONA_USER }}
+          SONA_PASS: ${{ secrets.SONA_PASS }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SONA_PGP_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SONA_PGP_SECRET }}
+
+      - name: Release on GitHub
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Version ${{ steps.version.outputs.TRACKER_VERSION }}
+          prerelease: ${{ contains(steps.version.outputs.TRACKER_VERSION, '-') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,19 @@
+Java 0.11.0 (2021-12-14)
+-----------------------
+Remove logging of user supplied values (#286)
+Update Deploy action to remove Bintray (#283)
+Set Emitter's threads name for easier debugging (#280)
+Update all copyright notices (#279)
+Allow Emitter to use a custom ExecutorService (#278)
+Specify the key for 'null or empty value detected' payload log (#277)
+Remove Mockito and Wiremock dependencies (#275)
+Update dependencies guava, wiremock, and httpclient (#269)
+Manually set the session_id (#265)
+Update gradle GH Action to include Java 17 (#273)
+Remove HttpHeaders dependency in OkHttpClientAdapter (#266)
+Replace Vagrant with Docker (#267)
+
+
 Java 0.10.1 (2020-06-11)
 -----------------------
 Publish Gradle module file with bintrayUpload (#255)

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ wrapper.gradleVersion = '6.5.0'
 
 group = 'com.snowplowanalytics'
 archivesBaseName = 'snowplow-java-tracker'
-version = '0.11.0-alpha.15'
+version = '0.11.0'
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,10 @@
  */
 
 plugins {
-    id 'com.jfrog.bintray' version '1.8.5'
     id 'java-library'
     id 'maven-publish'
+    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
+    id 'signing'
     id 'idea'
 }
 
@@ -22,14 +23,13 @@ wrapper.gradleVersion = '6.5.0'
 
 group = 'com.snowplowanalytics'
 archivesBaseName = 'snowplow-java-tracker'
-version = '0.10.1'
+version = '0.11.0-alpha.15'
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 
 def javaVersion = JavaVersion.VERSION_1_8
 
 repositories {
-    // Use 'maven central' for resolving our dependencies
     mavenCentral()
 }
 
@@ -193,49 +193,22 @@ publishing {
     }
 }
 
-// Workaround for upload of module.json file, remove when issue fixed https://github.com/bintray/gradle-bintray-plugin/issues/229
-bintrayUpload.doFirst {
-    publishing.publications.all { publication ->
-        def moduleFile = file("$buildDir/publications/$publication.name/module.json")
-        if (moduleFile.exists()) {
-            artifact(moduleFile) {
-                extension = "module"
-            }
+nexusPublishing {
+    repositories {
+        sonatype {
+            username = System.getenv('SONA_USER')
+            password = System.getenv('SONA_PASS')
         }
     }
 }
 
-bintray {
-    user = System.getenv('BINTRAY_SNOWPLOW_MAVEN_USER')
-    key = System.getenv('BINTRAY_SNOWPLOW_MAVEN_API_KEY')
-
-    publish = true
-
-    pkg {
-        repo = 'snowplow-maven'
-        name = 'snowplow-java-tracker'
-
-        group = 'com.snowplowanalytics'
-        userOrg = 'snowplow'
-
-        websiteUrl = 'https://github.com/snowplow/snowplow-java-tracker'
-        vcsUrl = 'https://github.com/snowplow/snowplow-java-tracker'
-        issueTrackerUrl = 'https://github.com/snowplow/snowplow-java-tracker/issues'
-
-        licenses = ['Apache-2.0']
-        publications = ['mavenJava']
-
-        version {
-            name = "$project.version"
-            gpg {
-                sign = true
-            }
-            mavenCentralSync {
-                sync = true
-                user = System.getenv('SONA_USER')
-                password = System.getenv('SONA_PASS')
-                close = '1'
-            }
-        }
+signing {
+    if (System.getenv('ORG_GRADLE_PROJECT_signingKey') && System.getenv('ORG_GRADLE_PROJECT_signingPassword')) {
+        println 'Found signing credentials. Signing...'
+        def signingKey = findProperty("signingKey")
+        def signingPassword = findProperty("signingPassword")
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign publishing.publications.mavenJava
+        println 'Used useInMemoryPgpKeys()'
     }
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Utils.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Utils.java
@@ -77,7 +77,8 @@ public class Utils {
             new URL(url).toURI();
             return true;
         } catch (Exception e) {
-            LOGGER.error("URI {} is not valid: {}", url, e.getMessage());
+            LOGGER.error("Invalid URI");
+            LOGGER.debug("URI {} is not valid: {}", url, e.getMessage());
             return false;
         }
     }
@@ -120,7 +121,8 @@ public class Utils {
         try {
             jString = objectMapper.writeValueAsString(map);
         } catch (JsonProcessingException e) {
-            LOGGER.error("Could not process Map {} into JSON String: {}", map, e.getMessage());
+            LOGGER.error("Could not process Map into JSON String");
+            LOGGER.debug("Could not process Map {} into JSON String: {}", map, e.getMessage());
         }
         return jString;
     }
@@ -142,7 +144,7 @@ public class Utils {
             String encodedVal = urlEncodeUTF8(map.get(key));
 
             // Do not add empty Keys
-            if (encodedKey != null && !encodedKey.isEmpty()) {
+            if (!encodedKey.isEmpty()) {
                 sb.append(String.format("%s=%s", encodedKey, encodedVal));
             }
         }
@@ -163,7 +165,8 @@ public class Utils {
             String encoded = URLEncoder.encode(s, "UTF-8");
             return encoded.replaceAll("\\+", "%20");
         } catch (Exception e) {
-            LOGGER.error("Object {} could not be encoded: {}", o, e.getMessage());
+            LOGGER.error("Object could not be encoded");
+            LOGGER.debug("Object {} could not be encoded: {}", o, e.getMessage());
             return "";
         }
     }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayload.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayload.java
@@ -40,11 +40,11 @@ public class TrackerPayload implements Payload {
     @Override
     public void add(final String key, final String value) {
         if (key == null || key.isEmpty()) {
-            LOGGER.error("Invalid key detected: {}", key);
+            LOGGER.error("Null or empty key detected");
             return;
         }
         if (value == null || value.isEmpty()) {
-            LOGGER.info("null or empty value detected: {}->{}", key, value);
+            LOGGER.debug("Null or empty value detected: {}->{}", key, value);
             return;
         }
         LOGGER.debug("Adding new kv pair: {}->{}", key, value);

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/UtilsTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/UtilsTest.java
@@ -60,6 +60,17 @@ public class UtilsTest {
     }
 
     @Test
+    public void testMapToJSONString() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("k1", "v1");
+        assertEquals("{\"k1\":\"v1\"}", Utils.mapToJSONString(payload));
+
+        Map<String, Object> payload2 = new LinkedHashMap<>();
+        payload2.put("k1", new Object());
+        assertEquals("", Utils.mapToJSONString(payload2));
+    }
+
+    @Test
     public void testMapToQueryString() {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("k1", "v1");


### PR DESCRIPTION
This version provides finer control over Emitter thread creation, as well as giving names to the threads for easier debugging. We also provide a method for setting the `session_id` event property.

### CHANGELOG

**New features:**
Set Emitter's threads name for easier debugging (#280)
Allow Emitter to use a custom ExecutorService (#278)
Manually set the session_id (#265)
Specify the key for 'null or empty value detected' payload log (#277)

**Bug fixes:**
Remove logging of user supplied values (#286)

**Under the hood:**
Update Deploy action to remove Bintray (#283)
Update all copyright notices (#279)
Remove Mockito and Wiremock dependencies (#275)
Update dependencies guava, wiremock, and httpclient (#269)
Update gradle GH Action to include Java 17 (#273)
Remove HttpHeaders dependency in OkHttpClientAdapter (#266)
Replace Vagrant with Docker (#267)