### PR TITLE
Enable shutdown of Tracker threads (close #297)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ wrapper.gradleVersion = '6.5.0'
 
 group = 'com.snowplowanalytics'
 archivesBaseName = 'snowplow-java-tracker'
-version = '0.11.0'
+version = '0.12.0-alpha.0'
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -229,7 +229,7 @@ public class BatchEmitter extends AbstractEmitter implements Closeable {
                 if (!executor.awaitTermination(closeTimeout, TimeUnit.SECONDS)) {
                     executor.shutdownNow();
                     if (!executor.awaitTermination(closeTimeout, TimeUnit.SECONDS))
-                        LOGGER.warn("Executor did not terminate");
+                        LOGGER.warn("Emitter executor did not terminate");
                 }
             } catch (final InterruptedException ie) {
                 executor.shutdownNow();

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/OkHttpClientAdapter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/OkHttpClientAdapter.java
@@ -142,7 +142,7 @@ public class OkHttpClientAdapter extends AbstractHttpClientAdapter {
         } catch (IOException e) {
             LOGGER.error("OkHttpClient POST Request failed: {}", e.getMessage());
         }
-        
+
         return returnValue;
     }
 }


### PR DESCRIPTION
For issue #297. A fix for issue #291 / PR #293.

The threads in the ScheduledThreadPool ExecutorService in the Tracker can now be stopped. This was causing the simple-console demo to hang.

The new method `tracker.close()` shuts down the Tracker threadpool, and also calls the BatchEmitter method `emitter.close()`, which interrupts the Emitter threads.