### PR TITLE
Update simple-console example (close #295) 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,12 +44,10 @@ jobs:
       run: ./gradlew test
 
     - name: Build simple-console example
-      working-directory: ./examples/simple-console
-      run: ./gradlew build -x test
-
-    - name: Test simple-console example
-      working-directory: ./examples/simple-console
-      run: ./gradlew test
+      run: |
+        ./gradlew publishToMavenLocal
+        cd examples/simple-console
+        ./gradlew build
 
     - name: Upload report if failed
       if: ${{ failure() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,14 @@ jobs:
     - name: Test with Gradle Wrapper
       run: ./gradlew test
 
+    - name: Build simple-console example
+      working-directory: ./examples/simple-console
+      run: ./gradlew build -x test
+
+    - name: Test simple-console example
+      working-directory: ./examples/simple-console
+      run: ./gradlew test
+
     - name: Upload report if failed
       if: ${{ failure() }}
       uses: actions/upload-artifact@v2

--- a/examples/simple-console/build.gradle
+++ b/examples/simple-console/build.gradle
@@ -5,7 +5,7 @@ sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 
 repositories {
-    mavenLocal()
+//    mavenLocal()
     mavenCentral()
 }
 
@@ -20,7 +20,7 @@ dependencies {
 
     implementation ('com.snowplowanalytics:snowplow-java-tracker:0.11.0') {
         capabilities {
-            requireCapability 'com.snowplowanalytics:snowplow-java-tracker-okhttp-support:0.10.1'
+            requireCapability 'com.snowplowanalytics:snowplow-java-tracker-okhttp-support:0.11.0'
         }
     }
 

--- a/examples/simple-console/build.gradle
+++ b/examples/simple-console/build.gradle
@@ -6,9 +6,6 @@ targetCompatibility = '1.8'
 
 repositories {
     mavenLocal()
-    maven {
-        url  "https://snowplow.bintray.com/snowplow-maven" 
-    }
     mavenCentral()
 }
 
@@ -19,9 +16,9 @@ test {
 }
 
 dependencies {
-    implementation 'com.snowplowanalytics:snowplow-java-tracker:0.10.1'
+    implementation 'com.snowplowanalytics:snowplow-java-tracker:0.11.0'
 
-    implementation ('com.snowplowanalytics:snowplow-java-tracker:0.10.1') {
+    implementation ('com.snowplowanalytics:snowplow-java-tracker:0.11.0') {
         capabilities {
             requireCapability 'com.snowplowanalytics:snowplow-java-tracker-okhttp-support:0.10.1'
         }

--- a/examples/simple-console/build.gradle
+++ b/examples/simple-console/build.gradle
@@ -5,7 +5,7 @@ sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 
 repositories {
-//    mavenLocal()
+    mavenLocal()
     mavenCentral()
 }
 
@@ -16,11 +16,11 @@ test {
 }
 
 dependencies {
-    implementation 'com.snowplowanalytics:snowplow-java-tracker:0.11.0'
+    implementation 'com.snowplowanalytics:snowplow-java-tracker:0.+'
 
-    implementation ('com.snowplowanalytics:snowplow-java-tracker:0.11.0') {
+    implementation ('com.snowplowanalytics:snowplow-java-tracker:0.+') {
         capabilities {
-            requireCapability 'com.snowplowanalytics:snowplow-java-tracker-okhttp-support:0.11.0'
+            requireCapability 'com.snowplowanalytics:snowplow-java-tracker-okhttp-support'
         }
     }
 

--- a/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
+++ b/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
@@ -16,15 +16,10 @@ package com.snowplowanalytics;
 import com.snowplowanalytics.snowplow.tracker.DevicePlatform;
 import com.snowplowanalytics.snowplow.tracker.Tracker;
 import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
-import com.snowplowanalytics.snowplow.tracker.emitter.Emitter;
 import com.snowplowanalytics.snowplow.tracker.events.*;
 import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
-import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 
 import java.util.List;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.concurrent.TimeUnit;
 import static java.util.Collections.singletonList;
 
 import com.google.common.collect.ImmutableMap;
@@ -39,7 +34,6 @@ public class Main {
     }
 
     public static void main(String[] args) {
-        Set<String> failedEventIds = new HashSet<String>();
         String collectorEndpoint = getUrlFromArgs(args);
 
         System.out.println("Sending events to " + collectorEndpoint);
@@ -52,7 +46,7 @@ public class Main {
         // build an emitter, this is used by the tracker to batch and schedule transmission of events
         BatchEmitter emitter = BatchEmitter.builder()
                 .url(collectorEndpoint)
-                .bufferSize(4) // send an event every time one is given (no batching). In production this number should be higher, depending on the size/event volume
+                .bufferSize(4) // send batches of 4 events. In production this number should be higher, depending on the size/event volume
                 .build();
 
         // now we have the emitter, we need a tracker to turn our events into something a Snowplow collector can understand
@@ -61,22 +55,22 @@ public class Main {
             .platform(DevicePlatform.ServerSideApp)
             .build();
 
-        // This is an example of a custom context
-        List<SelfDescribingJson> contexts = singletonList(
+        // This is an example of a custom context entity
+        List<SelfDescribingJson> entity = singletonList(
             new SelfDescribingJson(
                 "iglu:com.snowplowanalytics.iglu/anything-c/jsonschema/1-0-0",
                 ImmutableMap.of("foo", "bar")));
 
-        // This is a sample page view event, many other event types (such as self-describing events) are available
+        // This is a sample page view event
         PageView pageViewEvent = PageView.builder()
             .pageTitle("Snowplow Analytics")
             .pageUrl("https://www.snowplowanalytics.com")
             .referrer("https://www.google.com")
-            .customContext(contexts)
+            .customContext(entity)
             .build();
         
-        tracker.track(pageViewEvent); // the .track method schedules the event for delivery to Snowplow
-
+        // EcommerceTransactionItems are tracked as part of an EcommerceTransaction event
+        // They are processed into separate events during the `track()` call
         EcommerceTransactionItem item = EcommerceTransactionItem.builder()
             .itemId("order_id")
             .sku("sku")
@@ -85,9 +79,10 @@ public class Main {
             .name("name")
             .category("category")
             .currency("currency")
-            .customContext(contexts)
+            .customContext(entity)
             .build();
 
+        // EcommerceTransaction event
         EcommerceTransaction ecommerceTransaction = EcommerceTransaction.builder()
             .orderId("order_id")
             .totalValue(1.0)
@@ -98,31 +93,30 @@ public class Main {
             .state("state")
             .country("country")
             .currency("currency")
-            .items(item) // EcommerceTransactionItem events are added to a parent EcommerceTransaction
-            .customContext(contexts)
+            .items(item) // EcommerceTransactionItem events are added to a parent EcommerceTransaction here
+            .customContext(entity)
             .build();
 
-        tracker.track(ecommerceTransaction); // This will track two events
 
-        // This is an example of a custom "Unsutrcutred" event based on a schema
+        // This is an example of a custom "Unstructured" event based on a schema
+        // Unstructured events are also called "self-describing" events
+        // because of their SelfDescribingJson base
         Unstructured unstructured = Unstructured.builder()
             .eventData(new SelfDescribingJson(
                     "iglu:com.snowplowanalytics.iglu/anything-a/jsonschema/1-0-0",
                     ImmutableMap.of("foo", "bar")
             ))
-            .customContext(contexts)
+            .customContext(entity)
             .build();
 
-        tracker.track(unstructured);
 
         // This is an example of a ScreenView event which will be translated into an Unstructured event
         ScreenView screenView = ScreenView.builder()
             .name("name")
             .id("id")
-            .customContext(contexts)
+            .customContext(entity)
             .build();
 
-        tracker.track(screenView);
 
         // This is an example of a Timing event which will be translated into an Unstructured event
         Timing timing = Timing.builder()
@@ -130,13 +124,30 @@ public class Main {
             .label("label")
             .variable("variable")
             .timing(10)
-            .customContext(contexts)
+            .customContext(entity)
             .build();
 
+        // This is an example of a Stuctured event
+        Structured structured = Structured.builder()
+                .category("category")
+                .action("action")
+                .label("label")
+                .property("property")
+                .value(12.34)
+                .customContext(entity)
+                .build();
+
+        tracker.track(pageViewEvent); // the .track method schedules the event for delivery to Snowplow
+        tracker.track(ecommerceTransaction); // This will track two events
+        tracker.track(unstructured);
+        tracker.track(screenView);
         tracker.track(timing);
+        tracker.track(structured);
 
         // Will close all threads and force send remaining events
-        // should be 1 left to flush, as we send 5 events with a bufferSize of 4
+        // We tracked 6 events; one of them an EcommerceTransaction containing one item
+        // Therefore 7 events should be sent in total.
+        // The bufferSize is 4 so there should be 3 left to flush
         emitter.close();
     }
 

--- a/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
+++ b/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
@@ -34,7 +34,7 @@ public class Main {
         return args[0];
     }
 
-    public static void main(String[] args) throws InterruptedException {
+    public static void main(String[] args) {
         String collectorEndpoint = getUrlFromArgs(args);
 
         // the application id to attach to events
@@ -153,12 +153,7 @@ public class Main {
         tracker.track(timing);
         tracker.track(structured);
 
-        Thread.sleep(1000);
-
         // Will close all threads and force send remaining events
-        // We tracked 6 events; one of them an EcommerceTransaction containing one item
-        // Therefore 7 events should be sent in total.
-        // The bufferSize is 4 so there should be 3 left to flush
         tracker.close();
 
         System.out.println("Tracked 7 events");

--- a/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
+++ b/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
@@ -58,7 +58,7 @@ public class Main {
         System.out.println("Using tracker version " + tracker.getTrackerVersion());
 
         // This is an example of a custom context entity
-        List<SelfDescribingJson> entity = singletonList(
+        List<SelfDescribingJson> context = singletonList(
             new SelfDescribingJson(
                 "iglu:com.snowplowanalytics.iglu/anything-c/jsonschema/1-0-0",
                 ImmutableMap.of("foo", "bar")));
@@ -74,7 +74,7 @@ public class Main {
             .pageTitle("Snowplow Analytics")
             .pageUrl("https://www.snowplowanalytics.com")
             .referrer("https://www.google.com")
-            .customContext(entity)
+            .customContext(context)
             .subject(eventSubject)
             .build();
         
@@ -88,7 +88,7 @@ public class Main {
             .name("name")
             .category("category")
             .currency("currency")
-            .customContext(entity)
+            .customContext(context)
             .build();
 
         // EcommerceTransaction event
@@ -103,7 +103,7 @@ public class Main {
             .country("country")
             .currency("currency")
             .items(item) // EcommerceTransactionItem events are added to a parent EcommerceTransaction here
-            .customContext(entity)
+            .customContext(context)
             .build();
 
 
@@ -115,7 +115,7 @@ public class Main {
                     "iglu:com.snowplowanalytics.iglu/anything-a/jsonschema/1-0-0",
                     ImmutableMap.of("foo", "bar")
             ))
-            .customContext(entity)
+            .customContext(context)
             .build();
 
 
@@ -123,7 +123,7 @@ public class Main {
         ScreenView screenView = ScreenView.builder()
             .name("name")
             .id("id")
-            .customContext(entity)
+            .customContext(context)
             .build();
 
 
@@ -133,7 +133,7 @@ public class Main {
             .label("label")
             .variable("variable")
             .timing(10)
-            .customContext(entity)
+            .customContext(context)
             .build();
 
         // This is an example of a Structured event
@@ -143,7 +143,7 @@ public class Main {
                 .label("label")
                 .property("property")
                 .value(12.34)
-                .customContext(entity)
+                .customContext(context)
                 .build();
 
         tracker.track(pageViewEvent); // the .track method schedules the event for delivery to Snowplow

--- a/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
+++ b/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
@@ -14,6 +14,7 @@
 package com.snowplowanalytics;
 
 import com.snowplowanalytics.snowplow.tracker.DevicePlatform;
+import com.snowplowanalytics.snowplow.tracker.Subject;
 import com.snowplowanalytics.snowplow.tracker.Tracker;
 import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
 import com.snowplowanalytics.snowplow.tracker.events.*;
@@ -61,12 +62,19 @@ public class Main {
                 "iglu:com.snowplowanalytics.iglu/anything-c/jsonschema/1-0-0",
                 ImmutableMap.of("foo", "bar")));
 
+        // This is an example of a eventSubject for adding user data
+        Subject eventSubject = new Subject.SubjectBuilder().build();
+        eventSubject.setUserId("example@snowplowanalytics.com");
+        eventSubject.setLanguage("EN");
+
         // This is a sample page view event
+        // the eventSubject has been included in this event
         PageView pageViewEvent = PageView.builder()
             .pageTitle("Snowplow Analytics")
             .pageUrl("https://www.snowplowanalytics.com")
             .referrer("https://www.google.com")
             .customContext(entity)
+            .subject(eventSubject)
             .build();
         
         // EcommerceTransactionItems are tracked as part of an EcommerceTransaction event
@@ -127,7 +135,7 @@ public class Main {
             .customContext(entity)
             .build();
 
-        // This is an example of a Stuctured event
+        // This is an example of a Structured event
         Structured structured = Structured.builder()
                 .category("category")
                 .action("action")

--- a/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
+++ b/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
@@ -34,10 +34,8 @@ public class Main {
         return args[0];
     }
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws InterruptedException {
         String collectorEndpoint = getUrlFromArgs(args);
-
-        System.out.println("Sending events to " + collectorEndpoint);
 
         // the application id to attach to events
         String appId = "java-tracker-sample-console-app";
@@ -55,6 +53,9 @@ public class Main {
             .base64(true)
             .platform(DevicePlatform.ServerSideApp)
             .build();
+
+        System.out.println("Sending events to " + collectorEndpoint);
+        System.out.println("Using tracker version " + tracker.getTrackerVersion());
 
         // This is an example of a custom context entity
         List<SelfDescribingJson> entity = singletonList(
@@ -152,11 +153,15 @@ public class Main {
         tracker.track(timing);
         tracker.track(structured);
 
+        Thread.sleep(1000);
+
         // Will close all threads and force send remaining events
         // We tracked 6 events; one of them an EcommerceTransaction containing one item
         // Therefore 7 events should be sent in total.
         // The bufferSize is 4 so there should be 3 left to flush
-        emitter.close();
+        tracker.close();
+
+        System.out.println("Tracked 7 events");
     }
 
 }


### PR DESCRIPTION
For issue #295.

The simple-console demo app now demonstrates two more aspects of the Java tracker: the Structured event type, and the Subject class.

Building the simple-console is now tested as part of the GH Build workflow. Also, it has been updated to correctly handle the new Tracker threadpool, by calling `tracker.close()` rather than `emitter.close()` at the end.