### PR TITLE
Rename bufferSize to batchSize (close #306)

### DIFF
--- a/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
+++ b/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
@@ -48,12 +48,6 @@ public class Main {
                 .batchSize(4) // send batches of 4 events. In production this number should be higher, depending on the size/event volume
                 .build();
 
-        // For versions below 0.12.0, the batchSize property was called bufferSize
-//        BatchEmitter emitter = BatchEmitter.builder()
-//                .url(collectorEndpoint)
-//                .bufferSize(4) // send batches of 4 events. In production this number should be higher, depending on the size/event volume
-//                .build();
-
         // now we have the emitter, we need a tracker to turn our events into something a Snowplow collector can understand
         final Tracker tracker = new Tracker.TrackerBuilder(emitter, namespace, appId)
             .base64(true)

--- a/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
+++ b/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
@@ -45,8 +45,14 @@ public class Main {
         // build an emitter, this is used by the tracker to batch and schedule transmission of events
         BatchEmitter emitter = BatchEmitter.builder()
                 .url(collectorEndpoint)
-                .bufferSize(4) // send batches of 4 events. In production this number should be higher, depending on the size/event volume
+                .batchSize(4) // send batches of 4 events. In production this number should be higher, depending on the size/event volume
                 .build();
+
+        // For versions below 0.12.0, the batchSize property was called bufferSize
+//        BatchEmitter emitter = BatchEmitter.builder()
+//                .url(collectorEndpoint)
+//                .bufferSize(4) // send batches of 4 events. In production this number should be higher, depending on the size/event volume
+//                .build();
 
         // now we have the emitter, we need a tracker to turn our events into something a Snowplow collector can understand
         final Tracker tracker = new Tracker.TrackerBuilder(emitter, namespace, appId)
@@ -154,7 +160,7 @@ public class Main {
         tracker.track(structured);
 
         // Will close all threads and force send remaining events
-        tracker.close();
+        emitter.close();
 
         System.out.println("Tracked 7 events");
     }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/AbstractEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/AbstractEmitter.java
@@ -134,13 +134,13 @@ public abstract class AbstractEmitter implements Emitter {
     public abstract void add(TrackerPayload payload);
 
     /**
-     * Customize the emitter buffer size to any valid integer greater than zero.
+     * Customize the emitter batch size to any valid integer greater than zero.
      * Has no effect on SimpleEmitter
      *
-     * @param bufferSize number of events to collect before sending
+     * @param batchSize number of events to collect before sending
      */
     @Override
-    public abstract void setBufferSize(final int bufferSize);
+    public abstract void setBatchSize(final int batchSize);
 
     /**
      * Removes all payloads from the buffer and sends them
@@ -149,12 +149,12 @@ public abstract class AbstractEmitter implements Emitter {
     public abstract void flushBuffer();
 
     /**
-     * Gets the Emitter Buffer Size - Will always be 1 for SimpleEmitter
+     * Gets the Emitter Batch Size - Will always be 1 for SimpleEmitter
      *
-     * @return the buffer size
+     * @return the batch size
      */
     @Override
-    public abstract int getBufferSize();
+    public abstract int getBatchSize();
 
     /**
      * Returns List of Payloads that are in the buffer.

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/Emitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/Emitter.java
@@ -30,30 +30,27 @@ public interface Emitter {
     void add(TrackerPayload payload);
 
     /**
-     * Customize the emitter buffer size to any valid integer
+     * Customize the emitter batch size to any valid integer
      * greater than zero.
      * - Will only affect the BatchEmitter
      *
-     * @param bufferSize number of events to collect before
+     * @param batchSize number of events to collect before
      *                   sending
      */
-    void setBufferSize(int bufferSize);
+    void setBatchSize(int batchSize);
 
     /**
-     * When the buffer limit is reached sending of the buffer is
-     * initiated.
-     *
-     * This can be used to manually start sending.
+     * This can be used to manually send all buffered events.
      */
     void flushBuffer();
 
     /**
-     * Gets the Emitter Buffer Size
+     * Gets the Emitter Batch Size
      * - Will always be 1 for SimpleEmitter
      *
-     * @return the buffer size
+     * @return the batch size
      */
-    int getBufferSize();
+    int getBatchSize();
 
     /**
      * Returns the List of Payloads that are in the buffer.

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/SimpleEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/SimpleEmitter.java
@@ -100,25 +100,25 @@ public class SimpleEmitter extends AbstractEmitter {
     }
 
     /**
-     * Customize the emitter buffer size to any valid integer greater than zero.
+     * Customize the emitter batch size to any valid integer greater than zero.
      * Has no effect on SimpleEmitter
      *
-     * @param bufferSize number of events to collect before sending
+     * @param batchSize number of events to collect before sending
      */
     @Override
-    public void setBufferSize(final int bufferSize) {
-        if (bufferSize != 1) {
-            LOGGER.debug("Noop. SimpleEmitter buffer size must always be 1.");
+    public void setBatchSize(final int batchSize) {
+        if (batchSize != 1) {
+            LOGGER.debug("Noop. SimpleEmitter batch size must always be 1.");
         }
     }
 
     /**
-     * Gets the Emitter Buffer Size - Will always be 1 for SimpleEmitter
+     * Gets the Emitter batch Size - Will always be 1 for SimpleEmitter
      *
-     * @return the buffer size
+     * @return the batch size
      */
     @Override
-    public int getBufferSize() {
+    public int getBatchSize() {
         return 1;
     }
 }

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -41,13 +41,13 @@ public class TrackerTest {
         }
 
         @Override
-        public void setBufferSize(int bufferSize) {}
+        public void setBatchSize(int batchSize) {}
 
         @Override
         public void flushBuffer() {}
 
         @Override
-        public int getBufferSize() {
+        public int getBatchSize() {
             return 0;
         }
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
@@ -71,7 +71,7 @@ public class BatchEmitterTest {
         mockHttpClientAdapter = new MockHttpClientAdapter();
         emitter = BatchEmitter.builder()
                 .httpClientAdapter(mockHttpClientAdapter)
-                .bufferSize(10)
+                .batchSize(10)
                 .build();
     }
 
@@ -125,15 +125,15 @@ public class BatchEmitterTest {
     }
 
     @Test
-    public void setBufferSize_WithNegativeValue_ThrowInvalidArgumentException() {
-        Exception exception = Assert.assertThrows(IllegalArgumentException.class, () -> emitter.setBufferSize(-1));
-        Assert.assertEquals("bufferSize must be greater than 0", exception.getMessage());
+    public void setBatchSize_WithNegativeValue_ThrowInvalidArgumentException() {
+        Exception exception = Assert.assertThrows(IllegalArgumentException.class, () -> emitter.setBatchSize(-1));
+        Assert.assertEquals("batchSize must be greater than 0", exception.getMessage());
     }
 
     @Test
-    public void setAndGetBufferSizeWorksAsExpected() throws InterruptedException {
-        emitter.setBufferSize(2);
-        Assert.assertEquals(2, emitter.getBufferSize());
+    public void setAndGetBatchSizeWorksAsExpected() throws InterruptedException {
+        emitter.setBatchSize(2);
+        Assert.assertEquals(2, emitter.getBatchSize());
 
         List<TrackerPayload> payloads = createPayloads(2);
         for (TrackerPayload payload : payloads) {


### PR DESCRIPTION
Correcting the misnamed Emitter property that defines how many events should be included in a single request. It's a breaking change, but it will improve clarity.

Previously in BatchEmitter:
`Emitter.getBufferSize()` -> number of events per batch
`Emitter.getBuffer.size()` -> number of events currently in the buffer

Now:
`Emitter.getBatchSize()` -> number of events per batch
`Emitter.getBuffer.size()` -> number of events currently in the buffer