### PR TITLE
Return eventId from Tracker.track() (close #304)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,6 @@ dependencies {
     testCompileOnly 'junit:junit:4.13'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 
-    testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.2'
 }
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
@@ -21,6 +21,8 @@ import com.snowplowanalytics.snowplow.tracker.constants.Parameter;
 
 /**
  * An object for managing extra event decoration.
+ * All the properties are optional. However, the timezone is set by default,
+ * to that of the server.
  */
 public class Subject {
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -199,7 +199,7 @@ public class Tracker {
      * will be created from the Event. This is passed to the configured Emitter.
      * If the event was successfully added to the Emitter buffer for sending,
      * a list containing the payload's eventId string (a UUID) is returned.
-     * ECommerceTransactions will return all the relevant eventIds in the list.
+     * EcommerceTransactions will return all the relevant eventIds in the list.
      * If the Emitter event buffer is full, the payload will be lost. In this case, this method
      * returns a list containing null.
      * <p>
@@ -214,7 +214,8 @@ public class Tracker {
         // a list because Ecommerce events become multiple Payloads
         List<Event> processedEvents = eventTypeSpecificPreProcessing(event);
         for (Event processedEvent : processedEvents) {
-            // Event ID (eid) and device_created_timestamp (dtm) are generated when the TrackerPayload is created
+            // Event ID (eid) and device_created_timestamp (dtm) are generated when
+            // the TrackerPayload is created
             TrackerPayload payload = (TrackerPayload) processedEvent.getPayload();
 
             addTrackerParameters(payload);

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -256,6 +256,15 @@ public class Tracker {
         return eventList;
     }
 
+//    private void addDefaultPayloadParameters(Event event, TrackerPayload payload) {
+//        payload.add(Parameter.EID, Utils.getEventId());
+//        if (event.getTrueTimestamp() != null) {
+//            payload.add(Parameter.TRUE_TIMESTAMP, Long.toString(event.getTrueTimestamp()));
+//        }
+//        payload.add(Parameter.DEVICE_CREATED_TIMESTAMP, Long.toString(System.currentTimeMillis()));
+//
+//    }
+
     private void addTrackerParameters(TrackerPayload payload) {
         payload.add(Parameter.PLATFORM, this.parameters.getPlatform().toString());
         payload.add(Parameter.APP_ID, this.parameters.getAppId());

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -187,7 +187,7 @@ public class Tracker {
      * @return the wrapper containing the Tracker parameters
      */
     public TrackerParameters getParameters() {
-        return this.parameters;
+        return parameters;
     }
 
     // --- Event Tracking Functions

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/AbstractEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/AbstractEmitter.java
@@ -133,7 +133,7 @@ public abstract class AbstractEmitter implements Emitter {
      * @param payload an payload
      */
     @Override
-    public abstract void add(TrackerPayload payload);
+    public abstract boolean add(TrackerPayload payload);
 
     /**
      * Customize the emitter batch size to any valid integer greater than zero.

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -113,7 +113,7 @@ public class BatchEmitter extends AbstractEmitter implements Closeable {
      * @param payload a payload
      */
     @Override
-    public void add(final TrackerPayload payload) {
+    public boolean add(final TrackerPayload payload) {
         boolean result = eventStore.addEvent(payload);
 
         if (!isClosing) {
@@ -125,6 +125,8 @@ public class BatchEmitter extends AbstractEmitter implements Closeable {
         if (!result) {
             LOGGER.error("Unable to add payload to emitter, emitter buffer is full");
         }
+
+        return result;
     }
 
     /**

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -108,8 +108,7 @@ public class BatchEmitter extends AbstractEmitter implements Closeable {
     /**
      * Adds a TrackerPayload to the concurrent queue buffer
      * <p>
-     * <b>Implementation note: </b><em>Be aware that calling `close()` on a BatchEmitter instance
-     * has a side-effect and will shutdown that ExecutorService.</em>
+     * <b>Implementation note: </b><em>As a side effect it triggers an Emitter thread to emit a batch of events.</em>
      *
      * @param payload a payload
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/Emitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/Emitter.java
@@ -27,7 +27,7 @@ public interface Emitter {
      *
      * @param payload a payload to be emitted
      */
-    void add(TrackerPayload payload);
+    boolean add(TrackerPayload payload);
 
     /**
      * Customize the emitter batch size to any valid integer

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/SimpleEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/SimpleEmitter.java
@@ -56,8 +56,12 @@ public class SimpleEmitter extends AbstractEmitter {
      * @param payload a payload
      */
     @Override
-    public void add(TrackerPayload payload) {
+    public boolean add(TrackerPayload payload) {
         executor.execute(getGetRequestRunnable(payload));
+
+        // This result doesn't mean anything
+        // The return type is for BatchEmitter's benefit
+        return true;
     }
 
     /**

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/AbstractEvent.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/AbstractEvent.java
@@ -148,7 +148,7 @@ public abstract class AbstractEvent implements Event {
      */
     protected TrackerPayload putDefaultParams(TrackerPayload payload) {
         payload.add(Parameter.EID, Utils.getEventId());
-        if (getTrueTimestamp()!=null) {
+        if (getTrueTimestamp() != null) {
             payload.add(Parameter.TRUE_TIMESTAMP, Long.toString(getTrueTimestamp()));
         }
         payload.add(Parameter.DEVICE_CREATED_TIMESTAMP, Long.toString(System.currentTimeMillis()));

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/AbstractEvent.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/AbstractEvent.java
@@ -173,11 +173,11 @@ public abstract class AbstractEvent implements Event {
      * @return the TrackerPayload with appended values.
      */
     protected TrackerPayload putDefaultParams(TrackerPayload payload) {
-        payload.add(Parameter.EID, getEventId());
+        payload.add(Parameter.EID, Utils.getEventId());
         if (getTrueTimestamp()!=null) {
             payload.add(Parameter.TRUE_TIMESTAMP, Long.toString(getTrueTimestamp()));
         }
-        payload.add(Parameter.DEVICE_CREATED_TIMESTAMP, Long.toString(getDeviceCreatedTimestamp()));
+        payload.add(Parameter.DEVICE_CREATED_TIMESTAMP, Long.toString(System.currentTimeMillis()));
         return payload;
     }
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/AbstractEvent.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/AbstractEvent.java
@@ -146,12 +146,10 @@ public abstract class AbstractEvent implements Event {
      * @param payload the payload to add to.
      * @return the TrackerPayload with appended values.
      */
-    protected TrackerPayload putDefaultParams(TrackerPayload payload) {
-        payload.add(Parameter.EID, Utils.getEventId());
+    protected TrackerPayload putTrueTimestamp(TrackerPayload payload) {
         if (getTrueTimestamp() != null) {
             payload.add(Parameter.TRUE_TIMESTAMP, Long.toString(getTrueTimestamp()));
         }
-        payload.add(Parameter.DEVICE_CREATED_TIMESTAMP, Long.toString(System.currentTimeMillis()));
         return payload;
     }
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/AbstractEvent.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/AbstractEvent.java
@@ -40,22 +40,16 @@ public abstract class AbstractEvent implements Event {
 
     protected final List<SelfDescribingJson> context;
 
-    protected long deviceCreatedTimestamp;
-
     /**
      * The true timestamp may be null if none is set.
      */
     protected Long trueTimestamp;
-
-    protected final String eventId;
     protected final Subject subject;
 
     public static abstract class Builder<T extends Builder<T>> {
 
         private List<SelfDescribingJson> context = new LinkedList<>();
-        private long deviceCreatedTimestamp = System.currentTimeMillis();
         protected Long trueTimestamp = null;
-        private String eventId = Utils.getEventId();
         private Subject subject = null;
 
         protected abstract T self();
@@ -110,13 +104,9 @@ public abstract class AbstractEvent implements Event {
 
         // Precondition checks
         Preconditions.checkNotNull(builder.context);
-        Preconditions.checkNotNull(builder.eventId);
-        Preconditions.checkArgument(!builder.eventId.isEmpty(), "eventId cannot be empty");
 
         this.context = builder.context;
-        this.deviceCreatedTimestamp = builder.deviceCreatedTimestamp;
         this.trueTimestamp = builder.trueTimestamp;
-        this.eventId = builder.eventId;
         this.subject = builder.subject;
     }
 
@@ -129,27 +119,11 @@ public abstract class AbstractEvent implements Event {
     }
 
     /**
-     * @return the event's device created timestamp.
-     */
-    @Override
-    public long getDeviceCreatedTimestamp() {
-        return deviceCreatedTimestamp;
-    }
-
-    /**
      * @return the event's true timestamp.
      */
     @Override
     public Long getTrueTimestamp() {
         return trueTimestamp;
-    }
-
-    /**
-     * @return the event id
-     */
-    @Override
-    public String getEventId() {
-        return this.eventId;
     }
 
     /**

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/AbstractEvent.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/AbstractEvent.java
@@ -72,31 +72,6 @@ public abstract class AbstractEvent implements Event {
         }
 
         /**
-         * A custom event timestamp.
-         *
-         * @param timestamp the event timestamp as
-         *                  unix epoch
-         * @return itself
-         * Use {@link #trueTimestamp} or {@link #deviceCreatedTimestamp}
-         */
-        @Deprecated
-        public T timestamp(long timestamp) {
-            return deviceCreatedTimestamp(timestamp);
-        }
-
-        /**
-         * Adjust the device-created timestamp. This is usually not what you want, check {@link #trueTimestamp}.
-         *
-         * @param timestamp the event timestamp as
-         *                  unix epoch
-         * @return itself
-         */
-        public T deviceCreatedTimestamp(long timestamp) {
-            this.deviceCreatedTimestamp = timestamp;
-            return self();
-        }
-
-        /**
          * The true timestamp of that event (as determined by the user).
          *
          * @param timestamp the event timestamp as
@@ -105,17 +80,6 @@ public abstract class AbstractEvent implements Event {
          */
         public T trueTimestamp(Long timestamp) {
             this.trueTimestamp = timestamp;
-            return self();
-        }
-
-        /**
-         * A custom eventId for the event.
-         *
-         * @param eventId the eventId
-         * @return itself
-         */
-        public T eventId(String eventId) {
-            this.eventId = eventId;
             return self();
         }
 
@@ -162,15 +126,6 @@ public abstract class AbstractEvent implements Event {
     @Override
     public List<SelfDescribingJson> getContext() {
         return new ArrayList<>(this.context);
-    }
-
-    /**
-     * @return the event's timestamp
-     * @deprecated Use {@link #getTrueTimestamp()} or {@link #getDeviceCreatedTimestamp()}
-     */
-    @Override
-    public long getTimestamp() {
-        return this.deviceCreatedTimestamp;
     }
 
     /**

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransaction.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransaction.java
@@ -209,7 +209,7 @@ public class EcommerceTransaction extends AbstractEvent {
         payload.add(Parameter.TR_STATE, this.state);
         payload.add(Parameter.TR_COUNTRY, this.country);
         payload.add(Parameter.TR_CURRENCY, this.currency);
-        return putDefaultParams(payload);
+        return putTrueTimestamp(payload);
     }
 
     /**

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransactionItem.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransactionItem.java
@@ -142,25 +142,9 @@ public class EcommerceTransactionItem extends AbstractEvent {
 
     /**
      * @param timestamp the new timestamp
-     * Use {@link #setTrueTimestamp(long)} or {@link #setTrueTimestamp(long)}
-     */
-    @Deprecated
-    public void setTimestamp(long timestamp) {
-        setDeviceCreatedTimestamp(timestamp);
-    }
-
-    /**
-     * @param timestamp the new timestamp
      */
     public void setTrueTimestamp(long timestamp) {
         this.trueTimestamp = timestamp;
-    }
-
-    /**
-     * @param timestamp the new timestamp
-     */
-    public void setDeviceCreatedTimestamp(Long timestamp) {
-        this.deviceCreatedTimestamp = timestamp;
     }
 
     /**

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransactionItem.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransactionItem.java
@@ -163,6 +163,6 @@ public class EcommerceTransactionItem extends AbstractEvent {
         payload.add(Parameter.TI_ITEM_PRICE, Double.toString(this.price));
         payload.add(Parameter.TI_ITEM_QUANTITY, Integer.toString(this.quantity));
         payload.add(Parameter.TI_ITEM_CURRENCY, this.currency);
-        return putDefaultParams(payload);
+        return putTrueTimestamp(payload);
     }
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Event.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Event.java
@@ -29,13 +29,6 @@ public interface Event {
     List<SelfDescribingJson> getContext();
 
     /**
-     * @return the event's timestamp
-     * Use {@link #getTrueTimestamp()} or {@link #getDeviceCreatedTimestamp()}
-     */
-    @Deprecated
-    long getTimestamp();
-
-    /**
      * @return the event's true timestamp
      */
     Long getTrueTimestamp();

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Event.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Event.java
@@ -34,16 +34,6 @@ public interface Event {
     Long getTrueTimestamp();
 
     /**
-     * @return the event's device created timestamp
-     */
-    long getDeviceCreatedTimestamp();
-
-    /**
-     * @return the event id
-     */
-    String getEventId();
-
-    /**
      * @return the event subject
      */
     Subject getSubject();

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/PageView.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/PageView.java
@@ -102,6 +102,6 @@ public class PageView extends AbstractEvent {
         payload.add(Parameter.PAGE_URL, this.pageUrl);
         payload.add(Parameter.PAGE_TITLE, this.pageTitle);
         payload.add(Parameter.PAGE_REFR, this.referrer);
-        return putDefaultParams(payload);
+        return putTrueTimestamp(payload);
     }
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/ScreenView.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/ScreenView.java
@@ -19,6 +19,8 @@ import com.snowplowanalytics.snowplow.tracker.constants.Constants;
 import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 
+import java.util.LinkedHashMap;
+
 public class ScreenView extends AbstractEvent {
 
     private final String name;
@@ -79,9 +81,9 @@ public class ScreenView extends AbstractEvent {
      * @return the payload as a SelfDescribingJson.
      */
     public SelfDescribingJson getPayload() {
-        TrackerPayload payload = new TrackerPayload();
-        payload.add(Parameter.SV_ID, this.id);
-        payload.add(Parameter.SV_NAME, this.name);
+        LinkedHashMap<String,Object> payload = new LinkedHashMap<>();
+        payload.put(Parameter.SV_ID, this.id);
+        payload.put(Parameter.SV_NAME, this.name);
         return new SelfDescribingJson(Constants.SCHEMA_SCREEN_VIEW, payload);
     }
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Structured.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Structured.java
@@ -131,6 +131,6 @@ public class Structured extends AbstractEvent {
         payload.add(Parameter.SE_PROPERTY, this.property);
         payload.add(Parameter.SE_VALUE,
                 this.value != null ? Double.toString(this.value) : null);
-        return putDefaultParams(payload);
+        return putTrueTimestamp(payload);
     }
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Unstructured.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Unstructured.java
@@ -89,6 +89,6 @@ public class Unstructured extends AbstractEvent {
         payload.add(Parameter.EVENT, Constants.EVENT_UNSTRUCTURED);
         payload.addMap(envelope.getMap(), this.base64Encode,
                 Parameter.UNSTRUCTURED_ENCODED, Parameter.UNSTRUCTURED);
-        return putDefaultParams(payload);
+        return putTrueTimestamp(payload);
     }
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayload.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayload.java
@@ -29,6 +29,22 @@ public class TrackerPayload implements Payload {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TrackerPayload.class);
     protected final Map<String, String> payload = new LinkedHashMap<>();
+    private final String eventId;
+    private final Long deviceCreatedTimestamp;
+
+
+    public TrackerPayload() {
+        eventId = Utils.getEventId();
+        deviceCreatedTimestamp = System.currentTimeMillis();
+    }
+
+    public String getEventId() {
+        return eventId;
+    }
+
+    public Long getDeviceCreatedTimestamp() {
+        return deviceCreatedTimestamp;
+    }
 
     /**
      * Add a key-value pair to the payload: - Checks that the key is not null or

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayload.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayload.java
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import com.snowplowanalytics.snowplow.tracker.constants.Parameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +37,9 @@ public class TrackerPayload implements Payload {
     public TrackerPayload() {
         eventId = Utils.getEventId();
         deviceCreatedTimestamp = System.currentTimeMillis();
+
+        add(Parameter.EID, eventId);
+        add(Parameter.DEVICE_CREATED_TIMESTAMP, Long.toString(deviceCreatedTimestamp));
     }
 
     public String getEventId() {

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -15,8 +15,6 @@ package com.snowplowanalytics.snowplow.tracker;
 import java.util.*;
 import static java.util.Collections.singletonList;
 
-import com.snowplowanalytics.snowplow.tracker.emitter.BatchPayload;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -31,7 +29,6 @@ import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
 public class TrackerTest {
 
     public static final String EXPECTED_CONTEXTS = "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1\",\"data\":[{\"schema\":\"schema\",\"data\":{\"foo\":\"bar\"}}]}";
-    public static final String EXPECTED_EVENT_ID = "15e9b149-6029-4f6e-8447-5b9797c9e6be";
 
     public static class MockEmitter implements Emitter {
         public ArrayList<TrackerPayload> eventList = new ArrayList<>();
@@ -76,6 +73,27 @@ public class TrackerTest {
     // --- Event Tests
 
     @Test
+    public void testEventHasEventIdAndDeviceTimestamp() throws InterruptedException {
+        tracker.track(Unstructured.builder()
+                .eventData(new SelfDescribingJson(
+                        "iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0",
+                        ImmutableMap.of("foo", "bar")
+                ))
+                .build());
+
+        Thread.sleep(500);
+
+        Map<String, String> result = mockEmitter.eventList.get(0).getMap();
+
+        // this throws an exception if it's not a valid UUID string
+        UUID.fromString(result.get("eid"));
+
+        long currentTime = System.currentTimeMillis();
+        long timeDifference = Long.parseLong(result.get("dtm")) - currentTime;
+        assertTrue(timeDifference < 1000);
+    }
+
+    @Test
     public void testEcommerceEvent() throws InterruptedException {
         // Given
         EcommerceTransactionItem item = EcommerceTransactionItem.builder()
@@ -87,9 +105,7 @@ public class TrackerTest {
                 .category("category")
                 .currency("currency")
                 .customContext(contexts)
-                .deviceCreatedTimestamp(123456)
                 .trueTimestamp(456789L)
-                .eventId(EXPECTED_EVENT_ID)
                 .build();
 
         // When
@@ -105,9 +121,7 @@ public class TrackerTest {
                 .currency("currency")
                 .items(item)
                 .customContext(contexts)
-                .deviceCreatedTimestamp(123456)
                 .trueTimestamp(456789L)
-                .eventId(EXPECTED_EVENT_ID)
                 .build());
 
         // Then
@@ -117,15 +131,13 @@ public class TrackerTest {
         assertEquals(2, results.size());
 
         Map<String, String> result1 = results.get(0).getMap();
-        assertEquals(ImmutableMap.<String, String>builder()
+        Map<String, String> expected1 = ImmutableMap.<String, String>builder()
                 .put("e", "tr")
                 .put("tr_cu", "currency")
                 .put("co", EXPECTED_CONTEXTS)
-                .put("eid", EXPECTED_EVENT_ID)
                 .put("tna", "AF003")
                 .put("aid", "cloudfront")
                 .put("tr_sh", "3.0")
-                .put("dtm", "123456")
                 .put("ttm", "456789")
                 .put("tz", "Etc/UTC")
                 .put("tr_co", "country")
@@ -137,19 +149,19 @@ public class TrackerTest {
                 .put("tr_tt", "1.0")
                 .put("tr_ci", "city")
                 .put("tr_st", "state")
-                .build(), result1);
+                .build();
+
+        assertTrue(result1.entrySet().containsAll(expected1.entrySet()));
 
         Map<String, String> result2 = results.get(1).getMap();
-        assertEquals(ImmutableMap.<String, String>builder()
+        Map<String, String> expected2 = ImmutableMap.<String, String>builder()
                 .put("ti_nm", "name")
                 .put("ti_id", "order_id")
                 .put("e", "ti")
                 .put("co", EXPECTED_CONTEXTS)
-                .put("eid", EXPECTED_EVENT_ID)
                 .put("tna", "AF003")
                 .put("aid", "cloudfront")
                 .put("ti_cu", "currency")
-                .put("dtm", "123456")
                 .put("ttm", "456789")
                 .put("tz", "Etc/UTC")
                 .put("ti_pr", "1.0")
@@ -158,7 +170,9 @@ public class TrackerTest {
                 .put("tv", Version.TRACKER)
                 .put("ti_ca", "category")
                 .put("ti_sk", "sku")
-                .build(), result2);
+                .build();
+
+        assertTrue(result2.entrySet().containsAll(expected2.entrySet()));
     }
 
     @Test
@@ -166,32 +180,30 @@ public class TrackerTest {
         // When
         tracker.track(Unstructured.builder()
                 .eventData(new SelfDescribingJson(
-                        "payload",
+                        "iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0",
                         ImmutableMap.of("foo", "bar")
                 ))
                 .customContext(contexts)
-                .deviceCreatedTimestamp(123456)
                 .trueTimestamp(456789L)
-                .eventId(EXPECTED_EVENT_ID)
                 .build());
 
         // Then
         Thread.sleep(500);
 
         Map<String, String> result = mockEmitter.eventList.get(0).getMap();
-        assertEquals(ImmutableMap.<String, String>builder()
+        Map<String, String> expected = ImmutableMap.<String, String>builder()
                 .put("p", "srv")
                 .put("tv", Version.TRACKER)
                 .put("e", "ue")
                 .put("co", EXPECTED_CONTEXTS)
-                .put("eid", EXPECTED_EVENT_ID)
                 .put("tna", "AF003")
                 .put("tz", "Etc/UTC")
-                .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"payload\",\"data\":{\"foo\":\"bar\"}}}")
-                .put("dtm", "123456")
+                .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0\",\"data\":{\"foo\":\"bar\"}}}")
                 .put("ttm", "456789")
                 .put("aid", "cloudfront")
-                .build(), result);
+                .build();
+
+        assertTrue(result.entrySet().containsAll(expected.entrySet()));
     }
 
     @Test
@@ -199,30 +211,28 @@ public class TrackerTest {
         // When
         tracker.track(Unstructured.builder()
                 .eventData(new SelfDescribingJson(
-                        "payload",
+                        "iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0",
                         ImmutableMap.of("foo", "baær")
                 ))
-                .deviceCreatedTimestamp(123456)
                 .trueTimestamp(456789L)
-                .eventId(EXPECTED_EVENT_ID)
                 .build());
 
         // Then
         Thread.sleep(500);
 
         Map<String, String> result = mockEmitter.eventList.get(0).getMap();
-        assertEquals(ImmutableMap.<String, String>builder()
+        Map<String, String> expected = ImmutableMap.<String, String>builder()
                 .put("p", "srv")
                 .put("tv", Version.TRACKER)
-                .put("eid", EXPECTED_EVENT_ID)
                 .put("e", "ue")
                 .put("tna", "AF003")
                 .put("tz", "Etc/UTC")
-                .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"payload\",\"data\":{\"foo\":\"baær\"}}}")
-                .put("dtm", "123456")
+                .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0\",\"data\":{\"foo\":\"baær\"}}}")
                 .put("ttm", "456789")
                 .put("aid", "cloudfront")
-                .build(), result);
+                .build();
+
+        assertTrue(result.entrySet().containsAll(expected.entrySet()));
     }
 
     @Test
@@ -230,33 +240,31 @@ public class TrackerTest {
         // When
         tracker.track(Unstructured.builder()
                 .eventData(new SelfDescribingJson(
-                        "payload",
+                        "iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0",
                         ImmutableMap.of("foo", "baær")
                 ))
-                .deviceCreatedTimestamp(123456)
-                .eventId(EXPECTED_EVENT_ID)
                 .build());
 
         // Then
         Thread.sleep(500);
 
         Map<String, String> result = mockEmitter.eventList.get(0).getMap();
-        assertEquals(ImmutableMap.<String, String>builder()
+        Map<String, String> expected = ImmutableMap.<String, String>builder()
                 .put("p", "srv")
                 .put("tv", Version.TRACKER)
-                .put("eid", EXPECTED_EVENT_ID)
                 .put("e", "ue")
                 .put("tna", "AF003")
                 .put("tz", "Etc/UTC")
-                .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"payload\",\"data\":{\"foo\":\"baær\"}}}")
-                .put("dtm", "123456")
+                .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0\",\"data\":{\"foo\":\"baær\"}}}")
                 .put("aid", "cloudfront")
-                .build(), result);
+                .build();
+
+        assertTrue(result.entrySet().containsAll(expected.entrySet()));
     }
 
     @Test
     public void testTrackPageView() throws InterruptedException {
-        tracker = new Tracker.TrackerBuilder(this.mockEmitter, "AF003", "cloudfront")
+        tracker = new Tracker.TrackerBuilder(mockEmitter, "AF003", "cloudfront")
                 .subject(new Subject.SubjectBuilder().build())
                 .base64(false)
                 .build();
@@ -268,17 +276,14 @@ public class TrackerTest {
                 .pageTitle("title")
                 .referrer("referer")
                 .customContext(contexts)
-                .deviceCreatedTimestamp(123456)
                 .trueTimestamp(456789L)
-                .eventId(EXPECTED_EVENT_ID)
                 .build());
 
         // Then
         Thread.sleep(500);
 
         Map<String, String> result = mockEmitter.eventList.get(0).getMap();
-        assertEquals(ImmutableMap.<String, String>builder()
-                .put("dtm", "123456")
+        Map<String, String> expected = ImmutableMap.<String, String>builder()
                 .put("ttm", "456789")
                 .put("tz", "Etc/UTC")
                 .put("e", "pv")
@@ -286,12 +291,13 @@ public class TrackerTest {
                 .put("tv", Version.TRACKER)
                 .put("p", "srv")
                 .put("co", EXPECTED_CONTEXTS)
-                .put("eid", EXPECTED_EVENT_ID)
                 .put("tna", "AF003")
                 .put("aid", "cloudfront")
                 .put("refr", "referer")
                 .put("url", "url")
-                .build(), result);
+                .build();
+
+        assertTrue(result.entrySet().containsAll(expected.entrySet()));
     }
 
     @Test
@@ -301,9 +307,7 @@ public class TrackerTest {
                 .pageUrl("url")
                 .pageTitle("title")
                 .referrer("referer")
-                .deviceCreatedTimestamp(123456)
                 .trueTimestamp(456789L)
-                .eventId("9783090a-dace-4c85-a75c-933b4596a6c5")
                 .build());
 
         Thread.sleep(500);
@@ -312,9 +316,7 @@ public class TrackerTest {
                 .pageUrl("url")
                 .pageTitle("title")
                 .referrer("referer")
-                .deviceCreatedTimestamp(123456)
                 .trueTimestamp(456789L)
-                .eventId("39139d43-ea13-4163-8559-adea258bf9c4")
                 .build());
 
         // Then
@@ -324,36 +326,36 @@ public class TrackerTest {
         assertEquals(2, results.size());
 
         Map<String, String> result1 = results.get(0).getMap();
-        assertEquals(ImmutableMap.<String, String>builder()
-                .put("dtm", "123456")
+        Map<String, String> expected1 = ImmutableMap.<String, String>builder()
                 .put("ttm", "456789")
                 .put("tz", "Etc/UTC")
                 .put("e", "pv")
                 .put("page", "title")
                 .put("tv", Version.TRACKER)
                 .put("p", "srv")
-                .put("eid", "9783090a-dace-4c85-a75c-933b4596a6c5")
                 .put("tna", "AF003")
                 .put("aid", "cloudfront")
                 .put("refr", "referer")
                 .put("url", "url")
-                .build(), result1);
+                .build();
+
+        assertTrue(result1.entrySet().containsAll(expected1.entrySet()));
 
         Map<String, String> result2 = results.get(1).getMap();
-        assertEquals(ImmutableMap.<String, String>builder()
-                .put("dtm", "123456")
+        Map<String, String> expected2 = ImmutableMap.<String, String>builder()
                 .put("ttm", "456789")
                 .put("tz", "Etc/UTC")
                 .put("e", "pv")
                 .put("page", "title")
                 .put("tv", Version.TRACKER)
                 .put("p", "srv")
-                .put("eid", "39139d43-ea13-4163-8559-adea258bf9c4")
                 .put("tna", "AF003")
                 .put("aid", "cloudfront")
                 .put("refr", "referer")
                 .put("url", "url")
-                .build(), result2);
+                .build();
+
+        assertTrue(result2.entrySet().containsAll(expected2.entrySet()));
     }
 
     @Test
@@ -363,28 +365,26 @@ public class TrackerTest {
                 .name("name")
                 .id("id")
                 .customContext(contexts)
-                .deviceCreatedTimestamp(123456)
                 .trueTimestamp(456789L)
-                .eventId(EXPECTED_EVENT_ID)
                 .build());
 
         // Then
         Thread.sleep(500);
 
         Map<String, String> result = mockEmitter.eventList.get(0).getMap();
-        assertEquals(ImmutableMap.<String, String>builder()
-                .put("dtm", "123456")
+        Map<String, String> expected = ImmutableMap.<String, String>builder()
                 .put("ttm", "456789")
                 .put("tz", "Etc/UTC")
                 .put("e", "ue")
                 .put("tv", Version.TRACKER)
                 .put("p", "srv")
                 .put("co", EXPECTED_CONTEXTS)
-                .put("eid", EXPECTED_EVENT_ID)
                 .put("tna", "AF003")
                 .put("aid", "cloudfront")
                 .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0\",\"data\":{\"id\":\"id\",\"name\":\"name\"}}}")
-                .build(), result);
+                .build();
+
+        assertTrue(result.entrySet().containsAll(expected.entrySet()));
     }
 
     @Test
@@ -393,27 +393,25 @@ public class TrackerTest {
         tracker.track(ScreenView.builder()
                 .name("name")
                 .id("id")
-                .deviceCreatedTimestamp(123456)
                 .trueTimestamp(456789L)
-                .eventId(EXPECTED_EVENT_ID)
                 .build());
 
         // Then
         Thread.sleep(500);
 
         Map<String, String> result = mockEmitter.eventList.get(0).getMap();
-        assertEquals(ImmutableMap.<String, String>builder()
-                .put("dtm", "123456")
+        Map<String, String> expected = ImmutableMap.<String, String>builder()
                 .put("ttm", "456789")
                 .put("tz", "Etc/UTC")
                 .put("e", "ue")
                 .put("tv", Version.TRACKER)
                 .put("p", "srv")
-                .put("eid", EXPECTED_EVENT_ID)
                 .put("tna", "AF003")
                 .put("aid", "cloudfront")
                 .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0\",\"data\":{\"id\":\"id\",\"name\":\"name\"}}}")
-                .build(), result);
+                .build();
+
+        assertTrue(result.entrySet().containsAll(expected.entrySet()));
     }
 
     @Test
@@ -423,28 +421,26 @@ public class TrackerTest {
                 .name("name")
                 .id("id")
                 .customContext(contexts)
-                .deviceCreatedTimestamp(123456)
                 .trueTimestamp(456789L)
-                .eventId(EXPECTED_EVENT_ID)
                 .build());
 
         // Then
         Thread.sleep(500);
 
         Map<String, String> result = mockEmitter.eventList.get(0).getMap();
-        assertEquals(ImmutableMap.<String, String>builder()
+        Map<String, String> expected = ImmutableMap.<String, String>builder()
                 .put("p", "srv")
                 .put("tv", Version.TRACKER)
                 .put("e", "ue")
                 .put("co", EXPECTED_CONTEXTS)
-                .put("eid", EXPECTED_EVENT_ID)
                 .put("tna", "AF003")
                 .put("tz", "Etc/UTC")
                 .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0\",\"data\":{\"id\":\"id\",\"name\":\"name\"}}}")
-                .put("dtm", "123456")
                 .put("ttm", "456789")
                 .put("aid", "cloudfront")
-                .build(), result);
+                .build();
+
+        assertTrue(result.entrySet().containsAll(expected.entrySet()));
     }
 
     @Test
@@ -456,28 +452,26 @@ public class TrackerTest {
                 .variable("variable")
                 .timing(10)
                 .customContext(contexts)
-                .deviceCreatedTimestamp(123456)
                 .trueTimestamp(456789L)
-                .eventId(EXPECTED_EVENT_ID)
                 .build());
 
         // Then
         Thread.sleep(500);
 
         Map<String, String> result = mockEmitter.eventList.get(0).getMap();
-        assertEquals(ImmutableMap.<String, String>builder()
+        Map<String, String> expected = ImmutableMap.<String, String>builder()
                 .put("p", "srv")
                 .put("tv", Version.TRACKER)
                 .put("e", "ue")
                 .put("co", EXPECTED_CONTEXTS)
-                .put("eid", EXPECTED_EVENT_ID)
                 .put("tna", "AF003")
                 .put("tz", "Etc/UTC")
                 .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:com.snowplowanalytics.snowplow/timing/jsonschema/1-0-0\",\"data\":{\"category\":\"category\",\"label\":\"label\",\"timing\":10,\"variable\":\"variable\"}}}")
-                .put("dtm", "123456")
                 .put("ttm", "456789")
                 .put("aid", "cloudfront")
-                .build(), result);
+                .build();
+
+        assertTrue(result.entrySet().containsAll(expected.entrySet()));
     }
 
     @Test
@@ -494,9 +488,7 @@ public class TrackerTest {
                 .variable("variable")
                 .timing(10)
                 .customContext(contexts)
-                .deviceCreatedTimestamp(123456)
                 .trueTimestamp(456789L)
-                .eventId(EXPECTED_EVENT_ID)
                 .subject(s1)
                 .build());
 
@@ -504,20 +496,21 @@ public class TrackerTest {
         Thread.sleep(500);
 
         Map<String, String> result = mockEmitter.eventList.get(0).getMap();
-        assertEquals(ImmutableMap.<String, String>builder()
+        Map<String, String> expected = ImmutableMap.<String, String>builder()
                 .put("p", "srv")
                 .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:com.snowplowanalytics.snowplow/timing/jsonschema/1-0-0\",\"data\":{\"category\":\"category\",\"label\":\"label\",\"timing\":10,\"variable\":\"variable\"}}}")
                 .put("tv", Version.TRACKER)
                 .put("e", "ue")
                 .put("ip", "127.0.0.1")
                 .put("co", EXPECTED_CONTEXTS)
-                .put("eid", EXPECTED_EVENT_ID)
                 .put("tna", "AF003")
                 .put("tz", "Etc/UTC")
-                .put("dtm", "123456")
                 .put("ttm", "456789")
                 .put("aid", "cloudfront")
-                .build(), result);
+                .build();
+
+        assertTrue(result.entrySet().containsAll(expected.entrySet()));
+
     }
 
     // --- Tracker Setter & Getter Tests
@@ -538,17 +531,23 @@ public class TrackerTest {
 
     @Test
     public void testSetSubject() {
+        // Subject objects always have timezone set
         TimeZone.setDefault(TimeZone.getTimeZone("Etc/UTC"));
+
         Subject s1 = new Subject.SubjectBuilder().build();
+        s1.setLanguage("EN");
         Tracker tracker = new Tracker.TrackerBuilder(mockEmitter, "AF003", "cloudfront")
                 .subject(s1)
                 .build();
+
         Subject s2 = new Subject.SubjectBuilder().build();
         s2.setColorDepth(24);
         tracker.setSubject(s2);
+
         Map<String, String> subjectPairs = new HashMap<>();
         subjectPairs.put("tz", "Etc/UTC");
         subjectPairs.put("cd", "24");
+
         assertEquals(subjectPairs, tracker.getSubject().getSubject());
     }
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -77,8 +77,14 @@ public class TrackerTest {
 
         Thread.sleep(500);
 
-        // this throws an exception if it's not a valid UUID string
-        UUID.fromString(result.get(0));
+        boolean isValidEventId = true;
+        try {
+            UUID.fromString(result.get(0));
+        } catch (Exception e) {
+            isValidEventId = false;
+        }
+
+        assertTrue(isValidEventId);
     }
 
     @Test
@@ -258,7 +264,7 @@ public class TrackerTest {
         tracker.track(Unstructured.builder()
                 .eventData(new SelfDescribingJson(
                         "iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0",
-                        ImmutableMap.of("foo", "baær")
+                        ImmutableMap.of("foo", "bar")
                 ))
                 .build());
 
@@ -324,15 +330,14 @@ public class TrackerTest {
                 .pageUrl("url")
                 .pageTitle("title")
                 .referrer("referer")
-                .trueTimestamp(456789L)
+                .trueTimestamp(123456L)
                 .build());
 
-        Thread.sleep(500);
-
-        tracker.track(PageView.builder()
-                .pageUrl("url")
-                .pageTitle("title")
-                .referrer("referer")
+        tracker.track(Unstructured.builder()
+                .eventData(new SelfDescribingJson(
+                        "iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0",
+                        ImmutableMap.of("foo", "bar")
+                ))
                 .trueTimestamp(456789L)
                 .build());
 
@@ -344,7 +349,7 @@ public class TrackerTest {
 
         Map<String, String> result1 = results.get(0).getMap();
         Map<String, String> expected1 = ImmutableMap.<String, String>builder()
-                .put("ttm", "456789")
+                .put("ttm", "123456")
                 .put("tz", "Etc/UTC")
                 .put("e", "pv")
                 .put("page", "title")
@@ -361,15 +366,13 @@ public class TrackerTest {
         Map<String, String> result2 = results.get(1).getMap();
         Map<String, String> expected2 = ImmutableMap.<String, String>builder()
                 .put("ttm", "456789")
-                .put("tz", "Etc/UTC")
-                .put("e", "pv")
-                .put("page", "title")
-                .put("tv", Version.TRACKER)
                 .put("p", "srv")
+                .put("tv", Version.TRACKER)
+                .put("e", "ue")
                 .put("tna", "AF003")
+                .put("tz", "Etc/UTC")
+                .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0\",\"data\":{\"foo\":\"bar\"}}}")
                 .put("aid", "cloudfront")
-                .put("refr", "referer")
-                .put("url", "url")
                 .build();
 
         assertTrue(result2.entrySet().containsAll(expected2.entrySet()));
@@ -401,8 +404,6 @@ public class TrackerTest {
                 .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0\",\"data\":{\"id\":\"id\",\"name\":\"name\"}}}")
                 .build();
 
-        System.out.println(expected);
-        System.out.println(result);
         assertTrue(result.entrySet().containsAll(expected.entrySet()));
     }
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -66,28 +66,7 @@ public class TrackerTest {
     // --- Event Tests
 
     @Test
-    public void testEventHasEventIdAndDeviceTimestamp() throws InterruptedException {
-        tracker.track(Unstructured.builder()
-                .eventData(new SelfDescribingJson(
-                        "iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0",
-                        ImmutableMap.of("foo", "bar")
-                ))
-                .build());
-
-        Thread.sleep(500);
-
-        Map<String, String> result = mockEmitter.eventList.get(0).getMap();
-
-        // this throws an exception if it's not a valid UUID string
-        UUID.fromString(result.get("eid"));
-
-        long currentTime = System.currentTimeMillis();
-        long timeDifference = Long.parseLong(result.get("dtm")) - currentTime;
-        assertTrue(timeDifference < 1000);
-    }
-
-    @Test
-    public void testTrackReturnsEventID() throws InterruptedException {
+    public void testTrackReturnsEventIdIfSuccessful() throws InterruptedException {
         // a list to allow for eCommerceTransaction
         List<String> result = tracker.track(Unstructured.builder()
                 .eventData(new SelfDescribingJson(
@@ -128,7 +107,6 @@ public class TrackerTest {
 
         Thread.sleep(500);
 
-        // this throws an exception if it's not a valid UUID string
         assertNull(result.get(0));
     }
 
@@ -423,6 +401,8 @@ public class TrackerTest {
                 .put("ue_pr", "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0\",\"data\":{\"id\":\"id\",\"name\":\"name\"}}}")
                 .build();
 
+        System.out.println(expected);
+        System.out.println(result);
         assertTrue(result.entrySet().containsAll(expected.entrySet()));
     }
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
@@ -57,14 +57,10 @@ public class BatchEmitterTest {
         }
 
         @Override
-        public String getUrl() {
-            return null;
-        }
+        public String getUrl() { return null; }
 
         @Override
-        public Object getHttpClient() {
-            return null;
-        }
+        public Object getHttpClient() { return null; }
     }
 
     // this class fails to "send" the first 4 requests
@@ -84,19 +80,13 @@ public class BatchEmitterTest {
         }
 
         @Override
-        public int get(TrackerPayload payload) {
-            return 0;
-        }
+        public int get(TrackerPayload payload) { return 0; }
 
         @Override
-        public String getUrl() {
-            return null;
-        }
+        public String getUrl() { return null; }
 
         @Override
-        public Object getHttpClient() {
-            return null;
-        }
+        public Object getHttpClient() { return null; }
     }
 
     @Before
@@ -111,16 +101,15 @@ public class BatchEmitterTest {
 
     @Test
     public void addToBuffer_withLess10Payloads_shouldNotEmptyBuffer() throws InterruptedException {
-        List<TrackerPayload> payloads = createPayloads(2);
-        for (TrackerPayload payload : payloads) {
-            emitter.add(payload);
-        }
+        TrackerPayload payload = createPayload();
+        boolean result = emitter.add(payload);
 
         Thread.sleep(500);
 
+        Assert.assertTrue(result);
         Assert.assertFalse(mockHttpClientAdapter.isPostCalled);
-        Assert.assertEquals(2, emitter.getBuffer().size());
-        Assert.assertEquals(payloads, emitter.getBuffer());
+        Assert.assertEquals(1, emitter.getBuffer().size());
+        Assert.assertEquals(payload, emitter.getBuffer().get(0));
     }
 
     @Test
@@ -148,9 +137,10 @@ public class BatchEmitterTest {
         emitter.add(createPayload());
 
         TrackerPayload differentPayload = createPayload();
-        emitter.add(differentPayload);
+        boolean result = emitter.add(differentPayload);
 
         Assert.assertFalse(emitter.getBuffer().contains(differentPayload));
+        Assert.assertFalse(result);
     }
 
     @Test

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
@@ -25,9 +25,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-
 import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 import com.snowplowanalytics.snowplow.tracker.events.PageView;
@@ -136,8 +133,6 @@ public class BatchEmitterTest {
         Thread.sleep(500);
 
         Assert.assertTrue(mockHttpClientAdapter.isPostCalled);
-        @SuppressWarnings("unchecked")
-        List<Map<String, String>> capturedPayload = (List<Map<String, String>>) mockHttpClientAdapter.capturedPayload.getMap().get("data");
 
         Assert.assertEquals(0, emitter.getBuffer().size());
         Assert.assertEquals(1, mockHttpClientAdapter.postCounter);
@@ -358,10 +353,10 @@ public class BatchEmitterTest {
                     //Assert that all the entries in the event are in the captured payload
                     //There might be extra entries in capturedMap, such as the STM parameter
                     //check for these additional parameters in other tests
-                    assertThat(eventMap.entrySet(), everyItem(is(in(capturedMap.entrySet()))));
+                    Assert.assertTrue(capturedMap.entrySet().containsAll(eventMap.entrySet()));
                 }
             }
-            assertThat(matchFound, is(true)); //Ensure every event was found
+            Assert.assertTrue(matchFound); //Ensure every event was found
         }
     }
 }

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/http/HttpClientAdapterTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/http/HttpClientAdapterTest.java
@@ -92,10 +92,15 @@ public class HttpClientAdapterTest {
         data.add("space", "b a r");
         adapter.get(data);
 
+        String eventId = data.getEventId();
+        String dtm = Long.toString(data.getDeviceCreatedTimestamp());
+
         // Then
         assertEquals(1, mockWebServer.getRequestCount());
         RecordedRequest recordedRequest = mockWebServer.takeRequest();
-        assertEquals("/i?foo=bar&space=b%20a%20r", recordedRequest.getPath());
+
+        String expectedString = "/i?eid=" + eventId + "&dtm=" + dtm + "&foo=bar&space=b%20a%20r";
+        assertEquals(expectedString, recordedRequest.getPath());
         assertEquals("GET", recordedRequest.getMethod());
     }
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/payload/SelfDescribingJsonTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/payload/SelfDescribingJsonTest.java
@@ -47,8 +47,12 @@ public class SelfDescribingJsonTest {
     public void testMakeSdjWithTrackerPayload() {
         TrackerPayload data = new TrackerPayload();
         data.add("value", "key");
+        String eventId = data.getEventId();
+        String dtm = Long.toString(data.getDeviceCreatedTimestamp());
+
         SelfDescribingJson sdj = new SelfDescribingJson("schema_string", data);
-        String expected = "{\"schema\":\"schema_string\",\"data\":{\"value\":\"key\"}}";
+
+        String expected = "{\"schema\":\"schema_string\",\"data\":{\"eid\":\"" + eventId + "\",\"dtm\":\"" + dtm + "\",\"value\":\"key\"}}";
         String sdjString = sdj.toString();
         assertNotNull(sdj);
         assertEquals(expected, sdjString);

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayloadTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayloadTest.java
@@ -27,9 +27,15 @@ public class TrackerPayloadTest {
     @Test
     public void testGetEventId() {
         TrackerPayload payload = new TrackerPayload();
-        // this throws an exception if it's not a valid UUID string
-        UUID.fromString(payload.getEventId());
 
+        boolean isValidEventId = true;
+        try {
+            UUID.fromString(payload.getEventId());
+        } catch (Exception e) {
+            isValidEventId = false;
+        }
+
+        assertTrue(isValidEventId);
         assertTrue(payload.getMap().containsKey("eid"));
         assertEquals(payload.getEventId(), payload.getMap().get("eid"));
     }

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayloadTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayloadTest.java
@@ -29,6 +29,9 @@ public class TrackerPayloadTest {
         TrackerPayload payload = new TrackerPayload();
         // this throws an exception if it's not a valid UUID string
         UUID.fromString(payload.getEventId());
+
+        assertTrue(payload.getMap().containsKey("eid"));
+        assertEquals(payload.getEventId(), payload.getMap().get("eid"));
     }
 
     @Test
@@ -37,6 +40,9 @@ public class TrackerPayloadTest {
         TrackerPayload payload = new TrackerPayload();
         long timeDifference = payload.getDeviceCreatedTimestamp() - currentTime;
         assertTrue(timeDifference < 1000);
+
+        assertTrue(payload.getMap().containsKey("dtm"));
+        assertEquals(Long.toString(payload.getDeviceCreatedTimestamp()), payload.getMap().get("dtm"));
     }
 
     @Test

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayloadTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayloadTest.java
@@ -15,6 +15,7 @@ package com.snowplowanalytics.snowplow.tracker.payload;
 // Java
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 // JUnit
 import org.junit.Test;
@@ -22,6 +23,21 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class TrackerPayloadTest {
+
+    @Test
+    public void testGetEventId() {
+        TrackerPayload payload = new TrackerPayload();
+        // this throws an exception if it's not a valid UUID string
+        UUID.fromString(payload.getEventId());
+    }
+
+    @Test
+    public void testGetDeviceCreatedTimestamp() {
+        long currentTime = System.currentTimeMillis();
+        TrackerPayload payload = new TrackerPayload();
+        long timeDifference = payload.getDeviceCreatedTimestamp() - currentTime;
+        assertTrue(timeDifference < 1000);
+    }
 
     @Test
     public void testAddKeyValue() {


### PR DESCRIPTION
For issue #304.

These changes remove two inappropriate fields from Events, remove the Hamcrest dependency, and add a return type to `Tracker.track()`.

#### Bad stuff
Previously, `eventId` was an Event field. Users were able to provide their own event ID when building an Event, or one would be generated automatically. The eventId was passed to the payload on TrackerPayload creation, when `Event.getPayload()` was called during `Tracker.track()` - or before PR #293, during event sending by the Emitter. 

Snowplow pipelines rely on eventIds being unique; allowing it to be set manually was very risky.

Users were also still able to set `deviceCreatedTimestamp`, a legacy option from before the introduction of `trueTimestamp`. TrueTimestamp is designed specifically for users to set their own timestamp. Aside from that, setting deviceCreatedTimestamp then means it referred to when the Event was built, which isn't necessarily when it's tracked.

#### New stuff
EventId and deviceCreatedTimestamp are now fields of TrackerPayload, and are generated automatically on TrackerPayload initialisation. DeviceCreatedTimestamp now more accurately describes the time at which `Tracker.track()` was called.

Previously, users could access an Event's eventId using `Event.getEventId()` for use elsewhere in their application. We now return the eventId from `Tracker.track()`. If the payload was lost because the Emitter buffer was full, null is returned instead.

I also removed the Hamcrest test dependency, which was only used in a couple of places.

