### PR TITLE
Add Javadoc generation (close #137)

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,3 +27,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/docs/javadoc
+          allow_empty_commit: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,4 +27,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/docs/javadoc
-          allow_empty_commit: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,29 @@
+name: Documentation
+
+on:
+  push
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+
+      - name: Build
+        run: ./gradlew build
+
+      - name: Deploy to GitHub Pages
+        if: success()
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/docs/javadoc

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,7 +1,8 @@
 name: Documentation
 
 on:
-  push
+  push:
+    branches: [ master ]
 
 jobs:
   docs:

--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,9 @@ task generateSources {
  */
 package com.snowplowanalytics.snowplow.tracker;
 // DO NOT EDIT. AUTO-GENERATED.
+/**
+* The release version of the Snowplow Java tracker.
+*/
 public class Version {
     static final String TRACKER = "java-$project.version";
     static final String VERSION = "$project.version";

--- a/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
+++ b/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
@@ -148,12 +148,13 @@ public class Main {
                 .customContext(context)
                 .build();
 
-        tracker.track(pageViewEvent); // the .track method schedules the event for delivery to Snowplow
-        tracker.track(ecommerceTransaction); // This will track two events
-        tracker.track(unstructured);
-        tracker.track(screenView);
-        tracker.track(timing);
-        tracker.track(structured);
+//        tracker.track(pageViewEvent); // the .track method schedules the event for delivery to Snowplow
+//        tracker.track(ecommerceTransaction); // This will track two events
+//        tracker.track(unstructured);
+//        tracker.track(screenView);
+//        tracker.track(timing);
+//        tracker.track(structured);
+        tracker.track(item);
 
         // Will close all threads and force send remaining events
         emitter.close();

--- a/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
+++ b/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
@@ -148,13 +148,12 @@ public class Main {
                 .customContext(context)
                 .build();
 
-//        tracker.track(pageViewEvent); // the .track method schedules the event for delivery to Snowplow
-//        tracker.track(ecommerceTransaction); // This will track two events
-//        tracker.track(unstructured);
-//        tracker.track(screenView);
-//        tracker.track(timing);
-//        tracker.track(structured);
-        tracker.track(item);
+        tracker.track(pageViewEvent); // the .track method schedules the event for delivery to Snowplow
+        tracker.track(ecommerceTransaction); // This will track two events
+        tracker.track(unstructured);
+        tracker.track(screenView);
+        tracker.track(timing);
+        tracker.track(structured);
 
         // Will close all threads and force send remaining events
         emitter.close();

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/DevicePlatform.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/DevicePlatform.java
@@ -13,6 +13,9 @@
 
 package com.snowplowanalytics.snowplow.tracker;
 
+/**
+ * The supported platform options for Tracker objects.
+ */
 public enum DevicePlatform {
     Web {
         public String toString() {

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
@@ -115,6 +115,8 @@ public class Subject {
         }
 
         /**
+         * Note that timezone is set by default to the server's timezone
+         * (`TimeZone tz = Calendar.getInstance().getTimeZone().getID()`)
          * @param timezone a timezone string
          * @return itself
          */
@@ -236,7 +238,8 @@ public class Subject {
     }
 
     /**
-     * Sets the timezone parameter
+     * Sets the timezone parameter. Note that timezone is set by default to the server's timezone
+     * (`TimeZone tz = Calendar.getInstance().getTimeZone().getID()`);
      *
      * @param timezone a timezone string
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -21,8 +21,6 @@ import com.snowplowanalytics.snowplow.tracker.events.*;
 import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.tracker.payload.TrackerParameters;
 import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -34,7 +32,6 @@ public class Tracker {
     private Emitter emitter;
     private Subject subject;
     private final TrackerParameters parameters;
-    private static final Logger LOGGER = LoggerFactory.getLogger(Tracker.class);
 
     /**
      * Creates a new Snowplow Tracker.
@@ -89,6 +86,9 @@ public class Tracker {
         }
 
         /**
+         * The devicePlatform the tracker is running on ({@link DevicePlatform}).
+         * The default is "srv", ServerSideApp.
+         *
          * @param platform The device platform the tracker is running on
          * @return itself
          */
@@ -119,6 +119,8 @@ public class Tracker {
     // --- Setters
 
     /**
+     * Change the Emitter used to send events.
+     *
      * @param emitter a new emitter
      */
     public void setEmitter(Emitter emitter) {
@@ -145,14 +147,16 @@ public class Tracker {
     }
 
     /**
-     * @return the Tracker Subject
+     * @return the Tracker-associated Subject
      */
     public Subject getSubject() {
         return this.subject;
     }
 
     /**
-     * @return the tracker version that was set
+     * The Java tracker release version, e.g. 0.12.0.
+     *
+     * @return the tracker version
      */
     public String getTrackerVersion() {
         return this.parameters.getTrackerVersion();
@@ -166,7 +170,7 @@ public class Tracker {
     }
 
     /**
-     * @return the trackers set Application ID
+     * @return the tracker Application ID
      */
     public String getAppId() {
         return this.parameters.getAppId();
@@ -180,7 +184,7 @@ public class Tracker {
     }
 
     /**
-     * @return the Tracker platform
+     * @return the Tracker platform, e.g. "srv"
      */
     public DevicePlatform getPlatform() {
         return this.parameters.getPlatform();
@@ -196,8 +200,7 @@ public class Tracker {
     // --- Event Tracking Functions
 
     /**
-     * Handles tracking the different types of events that
-     * the Tracker can encounter.
+     * Handles tracking the different types of events.
      * A TrackerPayload object - or more than one, in the case of eCommerceTransaction events -
      * will be created from the Event. This is passed to the configured Emitter.
      * If the event was successfully added to the Emitter buffer for sending,
@@ -217,7 +220,7 @@ public class Tracker {
         // a list because Ecommerce events become multiple Payloads
         List<Event> processedEvents = eventTypeSpecificPreProcessing(event);
         for (Event processedEvent : processedEvents) {
-            // Event ID (eid) and device_created_timestamp (dtm) are generated when
+            // Event ID (eid) and device_created_timestamp (dtm) are generated now when
             // the TrackerPayload is created
             TrackerPayload payload = (TrackerPayload) processedEvent.getPayload();
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -26,6 +26,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
+/**
+ * Allows tracking of Events.
+ */
 public class Tracker {
 
     private Emitter emitter;

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -201,6 +201,7 @@ public class Tracker {
 
     /**
      * Handles tracking the different types of events.
+     *
      * A TrackerPayload object - or more than one, in the case of eCommerceTransaction events -
      * will be created from the Event. This is passed to the configured Emitter.
      * If the event was successfully added to the Emitter buffer for sending,

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/constants/Constants.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/constants/Constants.java
@@ -13,7 +13,7 @@
 package com.snowplowanalytics.snowplow.tracker.constants;
 
 /**
- * Constants which apply to schemas, event types
+ * Constants that apply to schemas, event types
  * and sending protocols.
  */
 public class Constants {

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/constants/Parameter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/constants/Parameter.java
@@ -13,6 +13,10 @@
 
 package com.snowplowanalytics.snowplow.tracker.constants;
 
+/**
+ * More constants that define the event properties, which apply to schemas, event types
+ * and sending protocols.
+ */
 public class Parameter {
     // General
     public static final String SCHEMA = "schema";

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/AbstractEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/AbstractEmitter.java
@@ -58,7 +58,7 @@ public abstract class AbstractEmitter implements Emitter {
         }
 
         /**
-         * Adds the HttpClientAdapter to the AbstractEmitter
+         * Adds a custom HttpClientAdapter to the AbstractEmitter. The default is OkHttpClientAdapter.
          *
          * @param httpClientAdapter the adapter to use
          * @return itself
@@ -69,7 +69,7 @@ public abstract class AbstractEmitter implements Emitter {
         }
 
         /**
-         * Sets the Thread Count for the ExecutorService
+         * Sets the Thread Count for the ScheduledExecutorService. The default is 50.
          *
          * @param threadCount the size of the thread pool
          * @return itself
@@ -80,8 +80,8 @@ public abstract class AbstractEmitter implements Emitter {
         }
 
         /**
-         * Sets the emitter url for when a httpClientAdapter is not specified
-         * Will be used to create the default OkHttpClientAdapter.
+         * Sets the emitter url for when a httpClientAdapter is not specified.
+         * It will be used to create the default OkHttpClientAdapter.
          *
          * @param collectorUrl the url for the default httpClientAdapter
          * @return itself

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchPayload.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchPayload.java
@@ -16,14 +16,16 @@ import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 
 import java.util.List;
 
-
+/**
+ * A wrapper for a number of TrackerPayloads.
+ */
 public class BatchPayload {
 
     private final Long batchId;
     private final List<TrackerPayload> payloads;
 
-    public BatchPayload(Long payloadId, List<TrackerPayload> payloads) {
-        this.batchId = payloadId;
+    public BatchPayload(Long batchId, List<TrackerPayload> payloads) {
+        this.batchId = batchId;
         this.payloads = payloads;
     }
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/Emitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/Emitter.java
@@ -26,6 +26,7 @@ public interface Emitter {
      * we have reached the buffer limit yet.
      *
      * @param payload a payload to be emitted
+     * @return if the payload was added to the buffer
      */
     boolean add(TrackerPayload payload);
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/EventStore.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/EventStore.java
@@ -4,15 +4,46 @@ import java.util.List;
 
 import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 
+/**
+ * EventStore interface. For buffering events in the Emitter.
+ */
 public interface EventStore {
 
+    /**
+     * Add TrackerPayload to buffer.
+     *
+     * @param trackerPayload the payload to add
+     * @return success or not
+     */
     boolean addEvent(TrackerPayload trackerPayload);
 
-    BatchPayload getEventsBatch(int numberToRemove);
+    /**
+     * Remove some TrackerPayloads from the buffer.
+     *
+     * @param numberToGet how many payloads to get
+     * @return a BatchPayload wrapper
+     */
+    BatchPayload getEventsBatch(int numberToGet);
 
+    /**
+     * Get a copy of all the TrackerPayloads in the buffer.
+     *
+     * @return List of all the stored events
+     */
     List<TrackerPayload> getAllEvents();
 
+    /**
+     * Finish processing events after a request has been made.
+     *
+     * @param successfullySent if the batch of events was successfully sent
+     * @param batchId the ID of the batch of events
+     */
     void cleanupAfterSendingAttempt(boolean successfullySent, long batchId);
 
+    /**
+     * Get the current size of the buffer.
+     *
+     * @return number of events currently in the buffer
+     */
     int size();
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStore.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStore.java
@@ -9,26 +9,59 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicLong;
 
+/**
+ * Buffers events (as TrackerPayloads) in memory for sending via the BatchEmitter.
+ *
+ * The TrackerPayloads are stored in a queue. When the BatchEmitter calls {@link #getEventsBatch(int)},
+ * the chosen number of TrackerPayloads are removed from the queue. The batch is added to a map of payloads
+ * that are currently being sent, and wrapped as a BatchPayload. This BatchPayload wrapper is returned to the
+ * Emitter.
+ *
+ * If the POST request is successful, the payloads are deleted from the map.
+ * If not, they are removed from the map and reinserted into the queue to be sent again.
+ */
 public class InMemoryEventStore implements EventStore {
     private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryEventStore.class);
     private final AtomicLong batchId = new AtomicLong(1);
 
-    public final LinkedBlockingDeque<TrackerPayload> eventBuffer;
-    public final ConcurrentHashMap<Long, List<TrackerPayload>> eventsBeingSent = new ConcurrentHashMap<>();
+    private final LinkedBlockingDeque<TrackerPayload> eventBuffer;
+    private final ConcurrentHashMap<Long, List<TrackerPayload>> eventsBeingSent = new ConcurrentHashMap<>();
 
+    /**
+     * Make a new InMemoryEventStore with default queue capacity (`Integer.MAX_VALUE`).
+     */
     public InMemoryEventStore() {
         eventBuffer = new LinkedBlockingDeque<>();
     }
 
+    /**
+     * Make a new InMemoryEventStore with user-set queue capacity.
+     *
+     * @param bufferCapacity the maximum number of events to buffer at once
+     */
     public InMemoryEventStore(int bufferCapacity) {
         eventBuffer = new LinkedBlockingDeque<>(bufferCapacity);
     }
 
+    /**
+     * Add TrackerPayload to buffer. Returns false if the buffer was full.
+     * Note that the event is lost in this case.
+     *
+     * @param trackerPayload the payload to add
+     * @return success or not
+     */
     @Override
     public boolean addEvent(TrackerPayload trackerPayload) {
         return eventBuffer.offer(trackerPayload);
     }
 
+    /**
+     * Remove some TrackerPayloads from the buffer. They are wrapped as a BatchPayload to return,
+     * and also stored in a separate collection inside InMemoryEventStore until the result of their POST request is known.
+     *
+     * @param numberToGet how many payloads to get
+     * @return a BatchPayload wrapper
+     */
     @Override
     public BatchPayload getEventsBatch(int numberToGet) {
         List<TrackerPayload> eventsToSend = new ArrayList<>();
@@ -42,6 +75,14 @@ public class InMemoryEventStore implements EventStore {
         return batchedEvents;
     }
 
+    /**
+     * Finish processing events after a request has been made. If the request was successful,
+     * the events are deleted from the InMemoryEventStore. If not, they are reinserted at the beginning
+     * of the buffer queue for another attempt.
+     *
+     * @param successfullySent if the batch of events was successfully sent
+     * @param batchId the ID of the batch of events
+     */
     @Override
     public void cleanupAfterSendingAttempt(boolean successfullySent, long batchId) {
         // Events that successfully sent are deleted from the pending buffer
@@ -62,12 +103,24 @@ public class InMemoryEventStore implements EventStore {
         }
     }
 
+    /**
+     * Get a copy of all the TrackerPayloads in the buffer. This does not include any events
+     * currently being sent by the BatchEmitter.
+     *
+     * @return List of all the stored events
+     */
     @Override
     public List<TrackerPayload> getAllEvents() {
         TrackerPayload[] events = eventBuffer.toArray(new TrackerPayload[0]);
         return Arrays.asList(events);
     }
 
+    /**
+     * Get the current size of the buffer. This does not include any events
+     * currently being sent by the BatchEmitter.
+     *
+     * @return number of events currently in the buffer
+     */
     @Override
     public int size() {
         return eventBuffer.size();

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStore.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStore.java
@@ -28,7 +28,7 @@ public class InMemoryEventStore implements EventStore {
     private final ConcurrentHashMap<Long, List<TrackerPayload>> eventsBeingSent = new ConcurrentHashMap<>();
 
     /**
-     * Make a new InMemoryEventStore with default queue capacity (`Integer.MAX_VALUE`).
+     * Make a new InMemoryEventStore with default queue capacity (Integer.MAX_VALUE).
      */
     public InMemoryEventStore() {
         eventBuffer = new LinkedBlockingDeque<>();

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/SimpleEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/SimpleEmitter.java
@@ -22,8 +22,8 @@ import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 import com.snowplowanalytics.snowplow.tracker.constants.Parameter;
 
 /**
- * An emitter which sends events as soon as they are received via
- * GET requests.
+ * An emitter which sends events one-by-one as soon as they are received, via
+ * GET requests. The events are sent asynchronously.
  */
 public class SimpleEmitter extends AbstractEmitter {
 
@@ -51,9 +51,10 @@ public class SimpleEmitter extends AbstractEmitter {
     }
 
     /**
-     * Adds an event to the buffer and instantly sends it
+     * Adds an event and instantly tries to send it.
      *
      * @param payload a payload
+     * @return true
      */
     @Override
     public boolean add(TrackerPayload payload) {
@@ -65,7 +66,7 @@ public class SimpleEmitter extends AbstractEmitter {
     }
 
     /**
-     * Sends buffered events, but SimpleEmitter does not buffer events
+     * Sends all the buffered events, but SimpleEmitter does not buffer events.
      * So has no effect
      */
     @Override

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/AbstractEvent.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/AbstractEvent.java
@@ -22,26 +22,26 @@ import com.google.common.base.Preconditions;
 
 // This library
 import com.snowplowanalytics.snowplow.tracker.Subject;
-import com.snowplowanalytics.snowplow.tracker.Utils;
 import com.snowplowanalytics.snowplow.tracker.constants.Parameter;
 import com.snowplowanalytics.snowplow.tracker.payload.Payload;
 import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 
 /**
- * Base AbstractEvent class which contains common
- * elements to all events:
- * - Custom Context: list of custom contexts or null
- * - Timestamp: user defined event timestamp or 0
- * - Event Id: a unique id for the event
- * - Subject: a unique Subject for the event
+ * Base AbstractEvent class which contains
+ * elements that can be set in all events. These are context, trueTimestamp, and Subject.
+ *
+ * Context is a list of custom SelfDescribingJson entities.
+ * TrueTimestamp is a user-defined timestamp.
+ * Subject is an event-specific Subject. Its fields will override those of the
+ * Tracker-associated Subject, if present.
  */
 public abstract class AbstractEvent implements Event {
 
     protected final List<SelfDescribingJson> context;
 
     /**
-     * The true timestamp may be null if none is set.
+     * The trueTimestamp may be null if none is set.
      */
     protected Long trueTimestamp;
     protected final Subject subject;
@@ -55,9 +55,9 @@ public abstract class AbstractEvent implements Event {
         protected abstract T self();
 
         /**
-         * Adds a list of custom contexts.
+         * Adds a list of custom context entities.
          *
-         * @param context the list of contexts
+         * @param context the list of entities
          * @return itself
          */
         public T customContext(List<SelfDescribingJson> context) {
@@ -78,7 +78,8 @@ public abstract class AbstractEvent implements Event {
         }
 
         /**
-         * A custom subject for the event.
+         * A custom subject for the event. Its fields will override those of the
+         * Tracker-associated Subject, if present.
          *
          * @param subject the eventId
          * @return itself

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransaction.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransaction.java
@@ -34,7 +34,7 @@ import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
  *
  * The specific items purchased in the transaction must be added as EcommerceTransactionItem objects.
  * This event type is different from the others in that it will generate more than one tracked event.
- * There will be one "transaction" event, and one "transaction item" event for every
+ * There will be one "transaction" ("tr") event, and one "transaction item" ("ti") event for every
  * EcommerceTransactionItem included in the EcommerceTransaction.
  *
  * To link the "transaction" and "transaction item" events, we recommend using the same orderId for the
@@ -214,8 +214,7 @@ public class EcommerceTransaction extends AbstractEvent {
     }
 
     /**
-     * Returns a TrackerPayload which can be stored into
-     * the local database.
+     * Returns a TrackerPayload which can be passed to an Emitter.
      *
      * @return the payload to be sent.
      */
@@ -237,7 +236,7 @@ public class EcommerceTransaction extends AbstractEvent {
     }
 
     /**
-     * The list of Transaction Items passed with the event.
+     * The list of EcommerceTransactionItems passed with the event.
      *
      * @return the items.
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransaction.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransaction.java
@@ -26,13 +26,19 @@ import com.snowplowanalytics.snowplow.tracker.constants.Constants;
 import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 
 /**
- * Constructs an EcommerceTransaction event object. This event type uses a legacy design.
- * Instead of as context entities, the specific items purchased in the
- * transaction are added as EcommerceTransactionItem objects.
+ * Constructs an EcommerceTransaction event object.
+ * <p>
+ * <b>Implementation note: </b><em>EcommerceTransaction/EcommerceTransactionItem uses a legacy design.
+ * We aim to deprecate it eventually. We advise using Unstructured events instead, and attaching the items
+ * as entities. </em>
  *
- * This event type is also different from the others in that it will generate more than one tracked event.
+ * The specific items purchased in the transaction must be added as EcommerceTransactionItem objects.
+ * This event type is different from the others in that it will generate more than one tracked event.
  * There will be one "transaction" event, and one "transaction item" event for every
  * EcommerceTransactionItem included in the EcommerceTransaction.
+ *
+ * To link the "transaction" and "transaction item" events, we recommend using the same orderId for the
+ * EcommerceTransaction and all attached EcommerceTransactionItems.
  *
  * To use the Currency Conversion pipeline enrichment, the currency string must be
  * a valid Open Exchange Rates value.

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransaction.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransaction.java
@@ -25,6 +25,18 @@ import com.snowplowanalytics.snowplow.tracker.constants.Parameter;
 import com.snowplowanalytics.snowplow.tracker.constants.Constants;
 import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 
+/**
+ * Constructs an EcommerceTransaction event object. This event type uses a legacy design.
+ * Instead of as context entities, the specific items purchased in the
+ * transaction are added as EcommerceTransactionItem objects.
+ *
+ * This event type is also different from the others in that it will generate more than one tracked event.
+ * There will be one "transaction" event, and one "transaction item" event for every
+ * EcommerceTransactionItem included in the EcommerceTransaction.
+ *
+ * To use the Currency Conversion pipeline enrichment, the currency string must be
+ * a valid Open Exchange Rates value.
+ */
 public class EcommerceTransaction extends AbstractEvent {
 
     private final String orderId;
@@ -133,6 +145,9 @@ public class EcommerceTransaction extends AbstractEvent {
         }
 
         /**
+         * Provide a list of EcommerceTransactionItems.
+         * An empty list is valid, but probably not very useful.
+         *
          * @param items The items in the transaction
          * @return itself
          */
@@ -142,6 +157,9 @@ public class EcommerceTransaction extends AbstractEvent {
         }
 
         /**
+         * Provide EcommerceTransactionItems directly, without explicitly adding them
+         * to a list beforehand.
+         *
          * @param itemArgs The items as a varargs argument
          * @return itself
          */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransactionItem.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransactionItem.java
@@ -21,6 +21,10 @@ import com.snowplowanalytics.snowplow.tracker.constants.Parameter;
 import com.snowplowanalytics.snowplow.tracker.constants.Constants;
 import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 
+/**
+ * Constructs an EcommerceTransactionItem object, used in EcommerceTransaction events.
+ * EcommerceTransactionItems cannot be tracked directly.
+ */
 public class EcommerceTransactionItem extends AbstractEvent {
 
     private final String itemId;

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransactionItem.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransactionItem.java
@@ -22,8 +22,21 @@ import com.snowplowanalytics.snowplow.tracker.constants.Constants;
 import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 
 /**
- * Constructs an EcommerceTransactionItem object, used in EcommerceTransaction events.
- * EcommerceTransactionItems cannot be tracked directly.
+ * Constructs an EcommerceTransactionItem object.
+ * <p>
+ * <b>Implementation note: </b><em>EcommerceTransaction/EcommerceTransactionItem uses a legacy design.
+ * We aim to deprecate it eventually. We advise using Unstructured events instead, and attaching the items
+ * as entities. </em>
+ *
+ * EcommerceTransactionItems were designed for attaching data about purchased items to a
+ * EcommerceTransaction event. They can technically be sent as events in their own right, but this is
+ * not supported.
+ *
+ * To link the "transaction" and "transaction item" events, we recommend using the same orderId for the
+ * EcommerceTransaction and all attached EcommerceTransactionItems.
+ *
+ * To use the Currency Conversion pipeline enrichment, the currency string must be
+ * a valid Open Exchange Rates value.
  */
 public class EcommerceTransactionItem extends AbstractEvent {
 
@@ -46,7 +59,7 @@ public class EcommerceTransactionItem extends AbstractEvent {
         private String currency;
 
         /**
-         * @param itemId Item ID
+         * @param itemId Item ID - ideally the same as the EcommerceTransaction orderId
          * @return itself
          */
         public T itemId(String itemId) {
@@ -142,13 +155,6 @@ public class EcommerceTransactionItem extends AbstractEvent {
         this.name = builder.name;
         this.category = builder.category;
         this.currency = builder.currency;
-    }
-
-    /**
-     * @param timestamp the new timestamp
-     */
-    public void setTrueTimestamp(long timestamp) {
-        this.trueTimestamp = timestamp;
     }
 
     /**

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransactionItem.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransactionItem.java
@@ -158,8 +158,7 @@ public class EcommerceTransactionItem extends AbstractEvent {
     }
 
     /**
-     * Returns a TrackerPayload which can be stored into
-     * the local database.
+     * Returns a TrackerPayload which can be passed to an Emitter.
      *
      * @return the payload to be sent.
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Event.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Event.java
@@ -24,7 +24,7 @@ import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
 public interface Event {
 
     /**
-     * @return the events custom context
+     * @return the event's custom context
      */
     List<SelfDescribingJson> getContext();
 
@@ -34,7 +34,7 @@ public interface Event {
     Long getTrueTimestamp();
 
     /**
-     * @return the event subject
+     * @return the event-associated Subject
      */
     Subject getSubject();
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/PageView.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/PageView.java
@@ -22,6 +22,8 @@ import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 
 /**
  * Constructs a PageView event object.
+ *
+ * When tracked, generates a "pv" or "page_view" event.
  */
 public class PageView extends AbstractEvent {
 
@@ -54,7 +56,7 @@ public class PageView extends AbstractEvent {
         }
 
         /**
-         * @param referrer Referrer of the page
+         * @param referrer Referrer URL of the page
          * @return itself
          */
         public T referrer(String referrer) {
@@ -91,8 +93,7 @@ public class PageView extends AbstractEvent {
     }
 
     /**
-     * Returns a TrackerPayload which can be stored into
-     * the local database.
+     * Returns a TrackerPayload which can be passed to an Emitter.
      *
      * @return the payload to be sent.
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/ScreenView.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/ScreenView.java
@@ -17,10 +17,14 @@ import com.google.common.base.Preconditions;
 import com.snowplowanalytics.snowplow.tracker.constants.Parameter;
 import com.snowplowanalytics.snowplow.tracker.constants.Constants;
 import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
-import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 
 import java.util.LinkedHashMap;
 
+/**
+ * Constructs a ScreenView event object.
+ *
+ * When tracked, generates an "unstructured" or "ue" event.
+ */
 public class ScreenView extends AbstractEvent {
 
     private final String name;
@@ -32,7 +36,7 @@ public class ScreenView extends AbstractEvent {
         private String id;
 
         /**
-         * @param name The name of the screen view event
+         * @param name The (human-readable) name of the screen view
          * @return itself
          */
         public T name(String name) {
@@ -76,7 +80,8 @@ public class ScreenView extends AbstractEvent {
     }
 
     /**
-     * Return the payload wrapped into a SelfDescribingJson.
+     * Return the payload wrapped into a SelfDescribingJson. When a ScreenView is tracked,
+     * the Tracker creates and tracks an Unstructured event from this SelfDescribingJson.
      *
      * @return the payload as a SelfDescribingJson.
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Structured.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Structured.java
@@ -22,6 +22,16 @@ import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 
 /**
  * Constructs a Structured event object.
+ *
+ * This event type is provided to be roughly equivalent to Google Analytics-style events.
+ * Note that it is not automatically clear what data should be placed in what field.
+ * To aid data quality and modeling, agree on business-wide definitions when designing
+ * your tracking strategy.
+ *
+ * We recommend using Unstructured - fully custom - events instead.
+ *
+ * When tracked, generates a "struct" or "se" event.
+ *
  */
 public class Structured extends AbstractEvent {
 
@@ -49,7 +59,7 @@ public class Structured extends AbstractEvent {
         }
 
         /**
-         * @param action The event itself
+         * @param action Describes what happened in the event
          * @return itself
          */
         public T action(String action) {
@@ -58,7 +68,7 @@ public class Structured extends AbstractEvent {
         }
 
         /**
-         * @param label Refer to the object the action is performed on
+         * @param label Refers to the object the action is performed on
          * @return itself
          */
         public T label(String label) {
@@ -117,8 +127,7 @@ public class Structured extends AbstractEvent {
     }
 
     /**
-     * Returns a TrackerPayload which can be stored into
-     * the local database.
+     * Returns a TrackerPayload which can be passed to an Emitter.
      *
      * @return the payload to be sent.
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Timing.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Timing.java
@@ -23,6 +23,11 @@ import com.snowplowanalytics.snowplow.tracker.constants.Parameter;
 import com.snowplowanalytics.snowplow.tracker.constants.Constants;
 import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
 
+/**
+ * Constructs a Timing event object.
+ *
+ * When tracked, generates an "unstructured" or "ue" event.
+ */
 public class Timing extends AbstractEvent {
 
     private final String category;
@@ -106,7 +111,8 @@ public class Timing extends AbstractEvent {
     }
 
     /**
-     * Return the payload wrapped into a SelfDescribingJson.
+     * Return the payload wrapped into a SelfDescribingJson. When a Timing event is tracked,
+     * the Tracker creates and tracks an Unstructured event from this SelfDescribingJson.
      *
      * @return the payload as a SelfDescribingJson.
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Unstructured.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Unstructured.java
@@ -23,6 +23,11 @@ import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 
 /**
  * Constructs an Unstructured event object.
+ *
+ * This is a customisable event type which allows you to track anything describable
+ * by a JsonSchema.
+ *
+ * When tracked, generates an "unstructured" or "ue" event.
  */
 public class Unstructured extends AbstractEvent {
 
@@ -34,9 +39,8 @@ public class Unstructured extends AbstractEvent {
         private SelfDescribingJson eventData;
 
         /**
-         * @param selfDescribingJson The properties of the event. Has two field:
-         *                  A "data" field containing the event properties and
-         *                  A "schema" field identifying the schema against which the data is validated
+         * @param selfDescribingJson The properties of the event. Has two fields: "data", containing the event properties,
+         *  and "schema", identifying the schema against which the data is validated
          * @return itself
          */
         public T eventData(SelfDescribingJson selfDescribingJson) {
@@ -77,8 +81,7 @@ public class Unstructured extends AbstractEvent {
     }
 
     /**
-     * Returns a TrackerPayload which can be stored into
-     * the local database.
+     * Returns a TrackerPayload which can be passed to an Emitter.
      *
      * @return the payload to be sent.
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/Payload.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/Payload.java
@@ -21,9 +21,9 @@ import java.util.Map;
 public interface Payload {
 
     /**
-     * Add a key-value pair to the payload:
-     * - Checks that the key is not null or empty
-     * - Checks that the value is not null or empty
+     * Add a key-value pair to the payload.
+     *
+     * It checks that neither the key nor value is null or empty.
      *
      * @param key The parameter key
      * @param value The parameter value as a String
@@ -31,8 +31,8 @@ public interface Payload {
     void add(String key, String value);
 
     /**
-     * Add all the mappings from the specified map. The effect is the equivalent to that of calling:
-     *  - add(String key, String value) for each key value pair.
+     * Add all the mappings from the specified map. The effect is the equivalent to that of calling
+     *  {@link #add(String, String)} for each key value pair.
      *
      * @param map Key-Value pairs to be stored in this payload
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/SelfDescribingJson.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/SelfDescribingJson.java
@@ -24,9 +24,9 @@ import com.snowplowanalytics.snowplow.tracker.Utils;
 import com.snowplowanalytics.snowplow.tracker.constants.Parameter;
 
 /**
- * Builds a SelfDescribingJson object which can contain two fields:
- * - Schema: the JsonSchema path for this Json
- * - Data: the data for this Json
+ * Builds a SelfDescribingJson object. SelfDescribingJson must contain only two fields, schema and data.
+ *
+ * Schema is the JsonSchema path for this Json. Data is the data.
  */
 public class SelfDescribingJson implements Payload {
 
@@ -35,7 +35,7 @@ public class SelfDescribingJson implements Payload {
 
     /**
      * Creates a SelfDescribingJson with only a Schema
-     * String and an empty data map.
+     * String and an empty data map. Data can be added later using {@link #setData(Object)}.
      *
      * @param schema the schema string
      */
@@ -46,6 +46,11 @@ public class SelfDescribingJson implements Payload {
     /**
      * Creates a SelfDescribingJson with a Schema and a
      * TrackerPayload object.
+     *
+     * Note that TrackerPayload objects are initialised with an eventId UUID and
+     * timestamp (deviceCreatedTimestamp), as they are the basis for sending events.
+     * Therefore, your SelfDescribingJson data will contain the keys "eid" and "dtm".
+     * This is unlikely to be what you want.
      *
      * @param schema the schema string
      * @param data a TrackerPayload object to be embedded as
@@ -59,7 +64,7 @@ public class SelfDescribingJson implements Payload {
     /**
      * Creates a SelfDescribingJson with a Schema and a
      * SelfDescribingJson object.  This can be used to
-     * nest SDJs inside of each other.
+     * nest SDJs inside each other.
      *
      * @param schema the schema string
      * @param data a SelfDescribingJson object to be embedded as
@@ -96,8 +101,12 @@ public class SelfDescribingJson implements Payload {
     }
 
     /**
-     * Adds data to the SelfDescribingJson
-     * - Accepts a TrackerPayload object
+     * Adds data to the SelfDescribingJson from a TrackerPayload object.
+     *
+     * Note that TrackerPayload objects are initialised with an eventId UUID and
+     * timestamp (deviceCreatedTimestamp), as they are the basis for sending events.
+     * Therefore, your SelfDescribingJson data will contain the keys "eid" and "dtm".
+     * This is unlikely to be what you want.
      *
      * @param data the data to be added to the SelfDescribingJson
      * @return this SelfDescribingJson

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerParameters.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerParameters.java
@@ -14,6 +14,9 @@ package com.snowplowanalytics.snowplow.tracker.payload;
 
 import com.snowplowanalytics.snowplow.tracker.DevicePlatform;
 
+/**
+ * A wrapper for Tracker properties.
+ */
 public class TrackerParameters {
 
     private final String trackerVersion;

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayload.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/payload/TrackerPayload.java
@@ -23,8 +23,14 @@ import org.slf4j.LoggerFactory;
 import com.snowplowanalytics.snowplow.tracker.Utils;
 
 /**
- * Returns a standard Tracker Payload consisting of
- * many key - pair values.
+ * A TrackerPayload stores a map of key - pair values.
+ *
+ * When the Emitter attempts to send a TrackerPayload, these pairs are extracted
+ * and added to the HTTP request (via a SelfDescribingJson).
+ * The deviceSentTimestamp ("stm") is added at that point.
+ *
+ * EventId and deviceCreatedTimestamp are added to the internal map at
+ * TrackerPayload initialization.
  */
 public class TrackerPayload implements Payload {
 
@@ -51,8 +57,8 @@ public class TrackerPayload implements Payload {
     }
 
     /**
-     * Add a key-value pair to the payload: - Checks that the key is not null or
-     * empty - Checks that the value is not null or empty
+     * Add a key-value pair to the payload.
+     * Checks that neither the key nor the value are null or empty.
      *
      * @param key   The parameter key
      * @param value The parameter value as a String
@@ -73,7 +79,7 @@ public class TrackerPayload implements Payload {
 
     /**
      * Add all the mappings from the specified map. The effect is the equivalent to
-     * that of calling: - add(String key, String value) for each key value pair.
+     * that of calling {@link #add(String, String)} for each key value pair.
      *
      * @param map Key-Value pairs to be stored in this payload
      */

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -199,6 +199,48 @@ public class TrackerTest {
     }
 
     @Test
+    public void testEcommerceTransactionItemAlone() throws InterruptedException {
+        // Although surprising, EcommerceTransactionItems are valid events and
+        // can be sent separately from EcommerceTransactions.
+
+        tracker.track(EcommerceTransactionItem.builder()
+                .itemId("order_id")
+                .sku("sku")
+                .price(1.0)
+                .quantity(2)
+                .name("name")
+                .category("category")
+                .currency("currency")
+                .customContext(contexts)
+                .trueTimestamp(456789L)
+                .build());
+
+        // Then
+        Thread.sleep(500);
+
+        Map<String, String> result = mockEmitter.eventList.get(0).getMap();
+        Map<String, String> expected = ImmutableMap.<String, String>builder()
+                .put("ti_nm", "name")
+                .put("ti_id", "order_id")
+                .put("e", "ti")
+                .put("co", EXPECTED_CONTEXTS)
+                .put("tna", "AF003")
+                .put("aid", "cloudfront")
+                .put("ti_cu", "currency")
+                .put("ttm", "456789")
+                .put("tz", "Etc/UTC")
+                .put("ti_pr", "1.0")
+                .put("ti_qu", "2")
+                .put("p", "srv")
+                .put("tv", Version.TRACKER)
+                .put("ti_ca", "category")
+                .put("ti_sk", "sku")
+                .build();
+
+        assertTrue(result.entrySet().containsAll(expected.entrySet()));
+    }
+
+    @Test
     public void testUnstructuredEventWithContext() throws InterruptedException {
         // When
         tracker.track(Unstructured.builder()


### PR DESCRIPTION
For issue #137.

The Java tracker already had Javadoc comments for API docs. These have been updated for recent changes and to cover more of the code, including the new-to-v0.12.0 EventStore and InMemoryEventStore.

A Github Workflow action has been added to push the built javadoc files to Github Pages. They are now published [here](https://snowplow.github.io/snowplow-java-tracker).

Weirdly, the pages within `com.snowplowanalytics.snowplow.tracker.events` do not show up using the default frames view. The links do nothing. But if "no frames" is chosen ([direct link](https://snowplow.github.io/snowplow-java-tracker/overview-summary.html), it's possible to load the pages.