### PR TITLE
Deprecate SimpleEmitter (close #309)

### DIFF
--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/AbstractEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/AbstractEmitter.java
@@ -29,6 +29,7 @@ import okhttp3.OkHttpClient;
 /**
  * AbstractEmitter class which contains common elements to
  * the emitters wrapped in a builder format.
+ * Note that SimpleEmitter has been deprecated.
  */
 public abstract class AbstractEmitter implements Emitter {
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/Emitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/Emitter.java
@@ -32,7 +32,7 @@ public interface Emitter {
     /**
      * Customize the emitter batch size to any valid integer
      * greater than zero.
-     * - Will only affect the BatchEmitter
+     * Will only affect the BatchEmitter
      *
      * @param batchSize number of events to collect before
      *                   sending
@@ -46,7 +46,7 @@ public interface Emitter {
 
     /**
      * Gets the Emitter Batch Size
-     * - Will always be 1 for SimpleEmitter
+     * Will always be 1 for SimpleEmitter. Note that SimpleEmitter has been deprecated.
      *
      * @return the batch size
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/SimpleEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/SimpleEmitter.java
@@ -24,7 +24,9 @@ import com.snowplowanalytics.snowplow.tracker.constants.Parameter;
 /**
  * An emitter which sends events as soon as they are received via
  * GET requests.
+ * @deprecated Use the BatchEmitter, or create your own Emitter using the provided interface.
  */
+@Deprecated
 public class SimpleEmitter extends AbstractEmitter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SimpleEmitter.class);


### PR DESCRIPTION
For issue #309.

We couldn't think of any situations in which the SimpleEmitter would be a better choice than the BatchEmitter.