### PR TITLE
Update JUnit and Jackson-databind dependencies (close #294)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,14 +73,14 @@ dependencies {
     testImplementation 'org.slf4j:slf4j-simple:1.7.30'
 
     // Jackson JSON processor
-    api 'com.fasterxml.jackson.core:jackson-databind:2.11.0'
+    api 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
 
     // Preconditions
     api 'com.google.guava:guava:31.0-jre'
 
     // Testing libraries
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-    testCompileOnly 'junit:junit:4.13'
+    testCompileOnly 'junit:junit:4.13.2'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.2'


### PR DESCRIPTION
For issue #294, to fix two known security vulnerabilities.

JUnit has been updated to v4.13.2.
Jackson-databind has been updated to v2.13.1.