### PR TITLE
Choose HTTP response codes not to retry (close #316)

### DIFF
--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -224,8 +224,7 @@ public class BatchEmitter extends AbstractEmitter implements Closeable {
             BatchPayload batchedEvents = null;
             try {
                 batchedEvents = eventStore.getEventsBatch(numberOfEvents);
-                if (batchedEvents == null || batchedEvents.size() == 0) {
-                    System.out.println("batchedEvents was null");
+                if (batchedEvents.size() == 0) {
                     return;
                 }
 
@@ -235,12 +234,12 @@ public class BatchEmitter extends AbstractEmitter implements Closeable {
 
                 // Process results
                 if (isSuccessfulSend(code)) {
-                    LOGGER.info("BatchEmitter successfully sent {} events: code: {}", eventsInRequest.size(), code);
+                    LOGGER.debug("BatchEmitter successfully sent {} events: code: {}", eventsInRequest.size(), code);
                     retryDelay.set(0L);
                     eventStore.cleanupAfterSendingAttempt(false, batchedEvents.getBatchId());
 
                 } else if (fatalResponseCodes.contains(code)) {
-                    LOGGER.info("BatchEmitter failed to send {} events. No retry for code {}: events dropped", eventsInRequest.size(), code);
+                    LOGGER.debug("BatchEmitter failed to send {} events. No retry for code {}: events dropped", eventsInRequest.size(), code);
                     eventStore.cleanupAfterSendingAttempt(false, batchedEvents.getBatchId());
 
                 } else {
@@ -255,7 +254,7 @@ public class BatchEmitter extends AbstractEmitter implements Closeable {
             } catch (Exception e) {
                 LOGGER.error("BatchEmitter event sending error: {}", e.getMessage());
                 if (batchedEvents != null) {
-                    eventStore.cleanupAfterSendingAttempt(false, batchedEvents.getBatchId());
+                    eventStore.cleanupAfterSendingAttempt(true, batchedEvents.getBatchId());
                 }
             }
         };

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -224,7 +224,8 @@ public class BatchEmitter extends AbstractEmitter implements Closeable {
             BatchPayload batchedEvents = null;
             try {
                 batchedEvents = eventStore.getEventsBatch(numberOfEvents);
-                if (batchedEvents.size() == 0) {
+
+                if (batchedEvents == null || batchedEvents.size() == 0) {
                     return;
                 }
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchPayload.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchPayload.java
@@ -36,4 +36,8 @@ public class BatchPayload {
     public List<TrackerPayload> getPayloads() {
         return payloads;
     }
+
+    public int size() {
+        return payloads.size();
+    }
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/EventStore.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/EventStore.java
@@ -47,10 +47,10 @@ public interface EventStore {
     /**
      * Finish processing events after a request has been made.
      *
-     * @param delete if false, move events back to the buffer instead of deleting
+     * @param needRetry if another attempt should be made to send the events
      * @param batchId the ID of the batch of events
      */
-    void deleteBatchedEvents(boolean delete, long batchId);
+    void cleanupAfterSendingAttempt(boolean needRetry, long batchId);
 
     /**
      * Get the current size of the buffer.

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/EventStore.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/EventStore.java
@@ -47,10 +47,10 @@ public interface EventStore {
     /**
      * Finish processing events after a request has been made.
      *
-     * @param successfullySent if the batch of events was successfully sent
+     * @param delete delete, or if false move events back to the buffer
      * @param batchId the ID of the batch of events
      */
-    void cleanupAfterSendingAttempt(boolean successfullySent, long batchId);
+    void deleteBatchedEvents(boolean delete, long batchId);
 
     /**
      * Get the current size of the buffer.

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/EventStore.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/EventStore.java
@@ -47,7 +47,7 @@ public interface EventStore {
     /**
      * Finish processing events after a request has been made.
      *
-     * @param delete delete, or if false move events back to the buffer
+     * @param delete if false, move events back to the buffer instead of deleting
      * @param batchId the ID of the batch of events
      */
     void deleteBatchedEvents(boolean delete, long batchId);

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStore.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStore.java
@@ -72,7 +72,7 @@ public class InMemoryEventStore implements EventStore {
      * and also stored in a separate collection inside InMemoryEventStore until the result of their POST request is known.
      *
      * @param numberToGet how many payloads to get
-     * @return a BatchPayload wrapper
+     * @return a BatchPayload wrapper, or null
      */
     @Override
     public BatchPayload getEventsBatch(int numberToGet) {
@@ -80,7 +80,7 @@ public class InMemoryEventStore implements EventStore {
 
         synchronized (eventBuffer) {
             if (eventBuffer.size() < numberToGet) {
-                return new BatchPayload(0L, eventsToSend);
+                return null;
             }
             eventBuffer.drainTo(eventsToSend, numberToGet);
         }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStore.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStore.java
@@ -92,17 +92,17 @@ public class InMemoryEventStore implements EventStore {
      * the events are deleted from the InMemoryEventStore. If not, they are reinserted at the beginning
      * of the buffer queue for another attempt.
      *
-     * @param successfullySent if the batch of events was successfully sent
+     * @param delete if the batch of events was successfully sent
      * @param batchId the ID of the batch of events
      */
     @Override
-    public void cleanupAfterSendingAttempt(boolean successfullySent, long batchId) {
+    public void deleteBatchedEvents(boolean delete, long batchId) {
         // Events that successfully sent are deleted from the pending buffer
         List<TrackerPayload> events = eventsBeingSent.remove(batchId);
 
         // Events that didn't send are inserted at the head of the eventBuffer
         // for immediate resending.
-        if (!successfullySent) {
+        if (!delete) {
             while (events.size() > 0) {
                 TrackerPayload payloadToReinsert = events.remove(0);
                 boolean result = eventBuffer.offerFirst(payloadToReinsert);

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStore.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStore.java
@@ -76,12 +76,13 @@ public class InMemoryEventStore implements EventStore {
      */
     @Override
     public BatchPayload getEventsBatch(int numberToGet) {
-        System.out.println("getting events batch, eventBuffer is: " + eventBuffer);
         List<TrackerPayload> eventsToSend = new ArrayList<>();
 
-        eventBuffer.drainTo(eventsToSend, numberToGet);
-        if (eventsToSend.isEmpty()) {
-            return null;
+        synchronized (eventBuffer) {
+            if (eventBuffer.size() < numberToGet) {
+                return new BatchPayload(0L, eventsToSend);
+            }
+            eventBuffer.drainTo(eventsToSend, numberToGet);
         }
 
         // The batch of events is wrapped as a BatchPayload

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStore.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStore.java
@@ -92,7 +92,7 @@ public class InMemoryEventStore implements EventStore {
      * the events are deleted from the InMemoryEventStore. If not, they are reinserted at the beginning
      * of the buffer queue for another attempt.
      *
-     * @param delete if the batch of events was successfully sent
+     * @param delete if false, move events back to the buffer instead of deleting
      * @param batchId the ID of the batch of events
      */
     @Override

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
@@ -346,10 +346,13 @@ public class BatchEmitterTest {
             emitter.add(payload);
         }
 
-        Thread.sleep(500);
+        Thread.sleep(2000);
+
+        System.out.println(emitter.getBuffer());
+        System.out.println(emitter.getBuffer().size());
 
         Assert.assertEquals(2, failingHttpClientAdapter.failedPostCounter);
-        Assert.assertEquals(100, emitter.getRetryDelay());
+        Assert.assertEquals(0, emitter.getRetryDelay());
         Assert.assertEquals(0, emitter.getBuffer().size());
     }
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
@@ -335,7 +335,7 @@ public class BatchEmitterTest {
 
         // the FailingHttpClientAdapter always returns 403
         FailingHttpClientAdapter failingHttpClientAdapter = new FailingHttpClientAdapter();
-        emitter = BatchEmitter.builder()
+        BatchEmitter emitter = BatchEmitter.builder()
                 .httpClientAdapter(failingHttpClientAdapter)
                 .batchSize(2)
                 .fatalResponseCodes(noRetry)
@@ -346,10 +346,7 @@ public class BatchEmitterTest {
             emitter.add(payload);
         }
 
-        Thread.sleep(2000);
-
-        System.out.println(emitter.getBuffer());
-        System.out.println(emitter.getBuffer().size());
+        Thread.sleep(500);
 
         Assert.assertEquals(2, failingHttpClientAdapter.failedPostCounter);
         Assert.assertEquals(0, emitter.getRetryDelay());

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
@@ -33,9 +33,10 @@ import com.snowplowanalytics.snowplow.tracker.http.HttpClientAdapter;
 public class BatchEmitterTest {
 
     private MockHttpClientAdapter mockHttpClientAdapter;
-    private FailingHttpClientAdapter failingHttpClientAdapter;
+    private FlakyHttpClientAdapter flakyHttpClientAdapter;
     private BatchEmitter emitter;
 
+    // MockHttpClientAdapter always returns 200
     public static class MockHttpClientAdapter implements HttpClientAdapter {
         public boolean isGetCalled = false;
         public boolean isPostCalled = false;
@@ -65,7 +66,7 @@ public class BatchEmitterTest {
 
     // this class fails to "send" the first 4 requests
     // but returns a successful result (200) subsequently
-    static class FailingHttpClientAdapter implements HttpClientAdapter {
+    static class FlakyHttpClientAdapter implements HttpClientAdapter {
         int failedPostCounter = 0;
         int successfulPostCounter = 0;
         @Override
@@ -89,10 +90,29 @@ public class BatchEmitterTest {
         public Object getHttpClient() { return null; }
     }
 
+    // This class always returns failure code 403
+    static class FailingHttpClientAdapter implements HttpClientAdapter {
+        int failedPostCounter = 0;
+        @Override
+        public int post(SelfDescribingJson payload) {
+            failedPostCounter++;
+            return 403;
+        }
+
+        @Override
+        public int get(TrackerPayload payload) { return 0; }
+
+        @Override
+        public String getUrl() { return null; }
+
+        @Override
+        public Object getHttpClient() { return null; }
+    }
+
     @Before
     public void setUp() {
         mockHttpClientAdapter = new MockHttpClientAdapter();
-        failingHttpClientAdapter = new FailingHttpClientAdapter();
+        flakyHttpClientAdapter = new FlakyHttpClientAdapter();
         emitter = BatchEmitter.builder()
                 .httpClientAdapter(mockHttpClientAdapter)
                 .batchSize(10)
@@ -252,7 +272,7 @@ public class BatchEmitterTest {
     @Test
     public void eventsThatFailToSendAreReturnedToEventBuffer() throws InterruptedException {
         emitter = BatchEmitter.builder()
-                .httpClientAdapter(new FailingHttpClientAdapter())
+                .httpClientAdapter(new FlakyHttpClientAdapter())
                 .batchSize(10)
                 .build();
 
@@ -273,7 +293,7 @@ public class BatchEmitterTest {
     @Test
     public void eventSendingFailureIncreasesBackoffTime() throws InterruptedException {
         emitter = BatchEmitter.builder()
-                .httpClientAdapter(failingHttpClientAdapter)
+                .httpClientAdapter(flakyHttpClientAdapter)
                 .batchSize(1)
                 .build();
 
@@ -288,11 +308,11 @@ public class BatchEmitterTest {
 
     @Test
     public void successfulSendAfterFailureResetsBackoffTime() throws InterruptedException {
-        // the FailingHttpClientAdapter returns 500 for the first 4 requests
+        // the FlakyHttpClientAdapter returns 500 for the first 4 requests
         // then subsequently returns 200
-        FailingHttpClientAdapter failingHttpClientAdapter = new FailingHttpClientAdapter();
+        FlakyHttpClientAdapter flakyHttpClientAdapter = new FlakyHttpClientAdapter();
         emitter = BatchEmitter.builder()
-                .httpClientAdapter(failingHttpClientAdapter)
+                .httpClientAdapter(flakyHttpClientAdapter)
                 .batchSize(1)
                 .threadCount(1)
                 .build();
@@ -304,8 +324,33 @@ public class BatchEmitterTest {
 
         Thread.sleep(500);
 
-        Assert.assertEquals(2, failingHttpClientAdapter.successfulPostCounter);
+        Assert.assertEquals(2, flakyHttpClientAdapter.successfulPostCounter);
         Assert.assertEquals(0, emitter.getRetryDelay());
+    }
+
+    @Test
+    public void noRetryAfterDenylistResponseCode() throws InterruptedException {
+        List<Integer> noRetry = new ArrayList<>();
+        noRetry.add(403);
+
+        // the FailingHttpClientAdapter always returns 403
+        FailingHttpClientAdapter failingHttpClientAdapter = new FailingHttpClientAdapter();
+        emitter = BatchEmitter.builder()
+                .httpClientAdapter(failingHttpClientAdapter)
+                .batchSize(2)
+                .fatalResponseCodes(noRetry)
+                .build();
+
+        List<TrackerPayload> payloads = createPayloads(4);
+        for (TrackerPayload payload : payloads) {
+            emitter.add(payload);
+        }
+
+        Thread.sleep(500);
+
+        Assert.assertEquals(2, failingHttpClientAdapter.failedPostCounter);
+        Assert.assertEquals(100, emitter.getRetryDelay());
+        Assert.assertEquals(0, emitter.getBuffer().size());
     }
 
     private TrackerPayload createPayload() {

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStoreTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStoreTest.java
@@ -75,7 +75,7 @@ public class InMemoryEventStoreTest {
 
         Assert.assertEquals(0, eventStore.size());
 
-        eventStore.deleteBatchedEvents(false, 1L);
+        eventStore.cleanupAfterSendingAttempt(true, 1L);
 
         Assert.assertEquals(2, eventStore.size());
     }
@@ -88,7 +88,7 @@ public class InMemoryEventStoreTest {
 
         Assert.assertEquals(0, eventStore.size());
 
-        eventStore.deleteBatchedEvents(true, 1L);
+        eventStore.cleanupAfterSendingAttempt(false, 1L);
 
         Assert.assertEquals(0, eventStore.size());
     }
@@ -106,7 +106,7 @@ public class InMemoryEventStoreTest {
         eventStore.addEvent(trackerPayload);
         eventStore.addEvent(trackerPayload);
 
-        eventStore.deleteBatchedEvents(false, 1L);
+        eventStore.cleanupAfterSendingAttempt(true, 1L);
         Assert.assertEquals(3, eventStore.size());
         Assert.assertTrue(eventStore.getAllEvents().contains(differentPayload));
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStoreTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStoreTest.java
@@ -58,13 +58,13 @@ public class InMemoryEventStoreTest {
     }
 
     @Test
-    public void doNotGetEventsIfFewerPresentThanAskedFor() {
+    public void doNotGetEventsIfFewerPresentThanAskedFor() throws NullPointerException {
         eventStore.addEvent(trackerPayload);
         eventStore.addEvent(trackerPayload);
 
-        List<TrackerPayload> events = eventStore.getEventsBatch(3).getPayloads();
+        BatchPayload events = eventStore.getEventsBatch(3);
 
-        Assert.assertEquals(0, events.size());
+        Assert.assertNull(events);
     }
 
     @Test

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStoreTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStoreTest.java
@@ -58,13 +58,13 @@ public class InMemoryEventStoreTest {
     }
 
     @Test
-    public void getAllEventsIfAskedForMoreEventsThanAreStored() {
+    public void doNotGetEventsIfFewerPresentThanAskedFor() {
         eventStore.addEvent(trackerPayload);
         eventStore.addEvent(trackerPayload);
 
         List<TrackerPayload> events = eventStore.getEventsBatch(3).getPayloads();
 
-        Assert.assertEquals(2, events.size());
+        Assert.assertEquals(0, events.size());
     }
 
     @Test

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStoreTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStoreTest.java
@@ -75,7 +75,7 @@ public class InMemoryEventStoreTest {
 
         Assert.assertEquals(0, eventStore.size());
 
-        eventStore.cleanupAfterSendingAttempt(false, 1L);
+        eventStore.deleteBatchedEvents(false, 1L);
 
         Assert.assertEquals(2, eventStore.size());
     }
@@ -88,7 +88,7 @@ public class InMemoryEventStoreTest {
 
         Assert.assertEquals(0, eventStore.size());
 
-        eventStore.cleanupAfterSendingAttempt(true, 1L);
+        eventStore.deleteBatchedEvents(true, 1L);
 
         Assert.assertEquals(0, eventStore.size());
     }
@@ -106,7 +106,7 @@ public class InMemoryEventStoreTest {
         eventStore.addEvent(trackerPayload);
         eventStore.addEvent(trackerPayload);
 
-        eventStore.cleanupAfterSendingAttempt(false, 1L);
+        eventStore.deleteBatchedEvents(false, 1L);
         Assert.assertEquals(3, eventStore.size());
         Assert.assertTrue(eventStore.getAllEvents().contains(differentPayload));
 


### PR DESCRIPTION
For issue #316.

A simple implementation to allow users to choose not to retry when certain HTTP response codes are received. The events are dropped instead.