### PR TITLE
Bump dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     testImplementation 'org.slf4j:slf4j-simple:1.7.30'
 
     // Jackson JSON processor
-    api 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
+    api 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
 
     // Preconditions
     api 'com.google.guava:guava:31.1-jre'

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
 
     // SLF4J logging API
     api 'org.slf4j:slf4j-api:1.7.30'
-    testImplementation 'org.slf4j:slf4j-simple:1.7.30'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.36'
 
     // Jackson JSON processor
     api 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 
     // Apache HTTP
     apachehttpSupportApi 'org.apache.httpcomponents:httpclient:4.5.13'
-    apachehttpSupportApi 'org.apache.httpcomponents:httpasyncclient:4.1.4'
+    apachehttpSupportApi 'org.apache.httpcomponents:httpasyncclient:4.1.5'
 
     // Square OK HTTP
     okhttpSupportApi 'com.squareup.okhttp3:okhttp:4.9.3'

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ test {
 
 dependencies {
     // Apache Commons
-    api 'commons-codec:commons-codec:1.14'
+    api 'commons-codec:commons-codec:1.15'
     api 'commons-net:commons-net:3.6'
 
     // Apache HTTP

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     testCompileOnly 'junit:junit:4.13.2'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.2'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.3'
 }
 
 task sourceJar(type: Jar, dependsOn: 'generateSources') {

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     api 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
 
     // Preconditions
-    api 'com.google.guava:guava:31.0-jre'
+    api 'com.google.guava:guava:31.1-jre'
 
     // Testing libraries
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     apachehttpSupportApi 'org.apache.httpcomponents:httpasyncclient:4.1.4'
 
     // Square OK HTTP
-    okhttpSupportApi 'com.squareup.okhttp3:okhttp:4.2.2'
+    okhttpSupportApi 'com.squareup.okhttp3:okhttp:4.9.3'
 
     // SLF4J logging API
     api 'org.slf4j:slf4j-api:1.7.36'

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     api 'com.google.guava:guava:31.0-jre'
 
     // Testing libraries
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testCompileOnly 'junit:junit:4.13.2'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     okhttpSupportApi 'com.squareup.okhttp3:okhttp:4.2.2'
 
     // SLF4J logging API
-    api 'org.slf4j:slf4j-api:1.7.30'
+    api 'org.slf4j:slf4j-api:1.7.36'
     testImplementation 'org.slf4j:slf4j-simple:1.7.36'
 
     // Jackson JSON processor

--- a/examples/simple-console/build.gradle
+++ b/examples/simple-console/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-simple:1.7.30'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    testCompileOnly 'junit:junit:4.13'
+    testCompileOnly 'junit:junit:4.13.2'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }
 

--- a/examples/simple-console/build.gradle
+++ b/examples/simple-console/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
     implementation 'org.slf4j:slf4j-simple:1.7.30'
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testCompileOnly 'junit:junit:4.13.2'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }

--- a/examples/simple-console/build.gradle
+++ b/examples/simple-console/build.gradle
@@ -24,7 +24,7 @@ dependencies {
         }
     }
 
-    implementation 'org.slf4j:slf4j-simple:1.7.30'
+    implementation 'org.slf4j:slf4j-simple:1.7.36'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testCompileOnly 'junit:junit:4.13.2'


### PR DESCRIPTION
* Bump junit to 4.13.2 (#330)
* Bump mockwebserver to 4.9.3 (#329)
* Bump junit-jupiter-api to 5.8.2 (#328)
* Bump guava to 31.1-jre (#327)
* Bump jackson-databind to 2.13.2.2 (#326)
* Bump slf4j-simple to 1.7.36 (#325)
* Bump slf4j-api to 1.7.36 (#324)
* Bump okhttp to 4.9.3 (#323)
* Bump httpasyncclient to 4.1.5 (#322)
* Bump commons-codec to 1.15 (#321)