### PR TITLE
Add support for storing cookies in OkHttpClientAdapter (close #336)

### DIFF
--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
@@ -309,8 +309,8 @@ public class Subject {
     }
 
     /**
-     * User inputted Network User Id for the
-     * subject.
+     * User inputted Network User ID for the subject.
+     * This overrides the network user ID set by the Collector in response Cookies.
      *
      * @param networkUserId a network user id
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/AbstractEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/AbstractEmitter.java
@@ -45,7 +45,7 @@ public abstract class AbstractEmitter implements Emitter {
         private int threadCount = 50; // Optional
         private ScheduledExecutorService requestExecutorService = null; // Optional
         private String collectorUrl = null; // Required if not specifying a httpClientAdapter
-        private CookieJar cookieJar; // Optional
+        private CookieJar cookieJar = null; // Optional
         protected abstract T self();
 
         /**
@@ -121,28 +121,34 @@ public abstract class AbstractEmitter implements Emitter {
     }
 
     protected AbstractEmitter(final Builder<?> builder) {
+        OkHttpClient client;
 
         // Precondition checks
         Preconditions.checkArgument(builder.threadCount > 0, "threadCount must be greater than 0");
 
         if (builder.httpClientAdapter != null) {
-            this.httpClientAdapter = builder.httpClientAdapter;
+            httpClientAdapter = builder.httpClientAdapter;
         } else {
             Preconditions.checkNotNull(builder.collectorUrl, "Collector url must be specified if not using a httpClientAdapter");
 
-            this.httpClientAdapter = OkHttpClientAdapter.builder() // use okhttp as a default
+            if (builder.cookieJar != null) {
+                client = new OkHttpClient.Builder()
+                        .cookieJar(builder.cookieJar)
+                        .build();
+            } else {
+                client = new OkHttpClient.Builder().build();
+            }
+
+            httpClientAdapter = OkHttpClientAdapter.builder() // use okhttp as a default
                     .url(builder.collectorUrl)
-                    .httpClient(
-                        new OkHttpClient.Builder()
-                                .cookieJar(builder.cookieJar == null ? new CollectorCookieJar() : builder.cookieJar)
-                                .build())
+                    .httpClient(client)
                     .build();
         }
 
         if (builder.requestExecutorService != null) {
-            this.executor = builder.requestExecutorService;
+            executor = builder.requestExecutorService;
         } else {
-            this.executor = Executors.newScheduledThreadPool(builder.threadCount, new EmitterThreadFactory());
+            executor = Executors.newScheduledThreadPool(builder.threadCount, new EmitterThreadFactory());
         }
     }
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/AbstractEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/AbstractEmitter.java
@@ -17,13 +17,16 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collector;
 
 import com.google.common.base.Preconditions;
 
+import com.snowplowanalytics.snowplow.tracker.http.CollectorCookieJar;
 import com.snowplowanalytics.snowplow.tracker.http.HttpClientAdapter;
 import com.snowplowanalytics.snowplow.tracker.http.OkHttpClientAdapter;
 
 import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
+import okhttp3.CookieJar;
 import okhttp3.OkHttpClient;
 
 /**
@@ -42,6 +45,7 @@ public abstract class AbstractEmitter implements Emitter {
         private int threadCount = 50; // Optional
         private ScheduledExecutorService requestExecutorService = null; // Optional
         private String collectorUrl = null; // Required if not specifying a httpClientAdapter
+        private CookieJar cookieJar; // Optional
         protected abstract T self();
 
         /**
@@ -91,6 +95,17 @@ public abstract class AbstractEmitter implements Emitter {
             this.collectorUrl = collectorUrl;
             return self();
         }
+
+        /**
+         * Adds a custom CookieJar to be used with OkHttpClientAdapters.
+         *
+         * @param cookieJar the CookieJar to use
+         * @return itself
+         */
+        public T cookieJar(final CookieJar cookieJar) {
+            this.cookieJar = cookieJar;
+            return self();
+        }
     }
 
     private static class Builder2 extends Builder<Builder2> {
@@ -118,6 +133,7 @@ public abstract class AbstractEmitter implements Emitter {
                     .url(builder.collectorUrl)
                     .httpClient(
                         new OkHttpClient()) // use okhttp as a default
+                    .cookieJar(builder.cookieJar)
                     .build();
         }
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/AbstractEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/AbstractEmitter.java
@@ -98,6 +98,7 @@ public abstract class AbstractEmitter implements Emitter {
 
         /**
          * Adds a custom CookieJar to be used with OkHttpClientAdapters.
+         * Will be ignored if a custom httpClientAdapter is provided.
          *
          * @param cookieJar the CookieJar to use
          * @return itself
@@ -129,11 +130,12 @@ public abstract class AbstractEmitter implements Emitter {
         } else {
             Preconditions.checkNotNull(builder.collectorUrl, "Collector url must be specified if not using a httpClientAdapter");
 
-            this.httpClientAdapter = OkHttpClientAdapter.builder()
+            this.httpClientAdapter = OkHttpClientAdapter.builder() // use okhttp as a default
                     .url(builder.collectorUrl)
                     .httpClient(
-                        new OkHttpClient()) // use okhttp as a default
-                    .cookieJar(builder.cookieJar)
+                        new OkHttpClient.Builder()
+                                .cookieJar(builder.cookieJar == null ? new CollectorCookieJar() : builder.cookieJar)
+                                .build())
                     .build();
         }
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/CollectorCookie.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/CollectorCookie.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2014-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
 package com.snowplowanalytics.snowplow.tracker.http;
 
 import okhttp3.Cookie;

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/CollectorCookie.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/CollectorCookie.java
@@ -1,0 +1,80 @@
+package com.snowplowanalytics.snowplow.tracker.http;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.Cookie;
+
+import java.util.*;
+
+public class CollectorCookie {
+    private final Cookie cookie;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    static List<CollectorCookie> decorateAll(Collection<Cookie> cookies) {
+        List<CollectorCookie> collectorCookies = new ArrayList<>(cookies.size());
+        for (Cookie cookie : cookies) {
+            collectorCookies.add(new CollectorCookie(cookie));
+        }
+        return collectorCookies;
+    }
+
+    CollectorCookie(Cookie cookie) {
+        this.cookie = cookie;
+    }
+
+    CollectorCookie(String serialized) throws JsonProcessingException {
+        // this probably won't work
+        cookie = objectMapper.readValue(serialized, Cookie.class);
+
+//        JSONObject object = new JSONObject(serialized);
+//        cookie = new Cookie.Builder()
+//                .name(object.getString("name"))
+//                .value(object.getString("value"))
+//                .expiresAt(object.getLong("expiresAt"))
+//                .domain(object.getString("domain"))
+//                .path(object.getString("path"))
+//                .build();
+    }
+
+    public boolean isExpired() {
+        return cookie.expiresAt() < System.currentTimeMillis();
+    }
+
+    Cookie getCookie() {
+        return cookie;
+    }
+
+    String getCookieKey() {
+        return (cookie.secure() ? "https" : "http") + "://" + cookie.domain() + cookie.path() + "|" + cookie.name();
+    }
+
+    public String serialize() throws JsonProcessingException {
+        HashMap<String, Object> values = new HashMap<String, Object>();
+        values.put("name", cookie.name());
+        values.put("value", cookie.value());
+        values.put("expiresAt", cookie.expiresAt());
+        values.put("domain", cookie.domain());
+        values.put("path", cookie.path());
+        return objectMapper.writeValueAsString(values);
+
+//        return new JSONObject(values).toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof CollectorCookie)) return false;
+        CollectorCookie that = (CollectorCookie) other;
+        return that.cookie.name().equals(this.cookie.name())
+                && that.cookie.domain().equals(this.cookie.domain())
+                && that.cookie.path().equals(this.cookie.path());
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 17;
+        hash = 31 * hash + cookie.name().hashCode();
+        hash = 31 * hash + cookie.domain().hashCode();
+        hash = 31 * hash + cookie.path().hashCode();
+        return hash;
+    }
+}

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/CollectorCookie.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/CollectorCookie.java
@@ -1,14 +1,11 @@
 package com.snowplowanalytics.snowplow.tracker.http;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.Cookie;
 
 import java.util.*;
 
 public class CollectorCookie {
     private final Cookie cookie;
-    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     static List<CollectorCookie> decorateAll(Collection<Cookie> cookies) {
         List<CollectorCookie> collectorCookies = new ArrayList<>(cookies.size());
@@ -22,42 +19,12 @@ public class CollectorCookie {
         this.cookie = cookie;
     }
 
-    CollectorCookie(String serialized) throws JsonProcessingException {
-        // this probably won't work
-        cookie = objectMapper.readValue(serialized, Cookie.class);
-
-//        JSONObject object = new JSONObject(serialized);
-//        cookie = new Cookie.Builder()
-//                .name(object.getString("name"))
-//                .value(object.getString("value"))
-//                .expiresAt(object.getLong("expiresAt"))
-//                .domain(object.getString("domain"))
-//                .path(object.getString("path"))
-//                .build();
-    }
-
     public boolean isExpired() {
         return cookie.expiresAt() < System.currentTimeMillis();
     }
 
     Cookie getCookie() {
         return cookie;
-    }
-
-    String getCookieKey() {
-        return (cookie.secure() ? "https" : "http") + "://" + cookie.domain() + cookie.path() + "|" + cookie.name();
-    }
-
-    public String serialize() throws JsonProcessingException {
-        HashMap<String, Object> values = new HashMap<String, Object>();
-        values.put("name", cookie.name());
-        values.put("value", cookie.value());
-        values.put("expiresAt", cookie.expiresAt());
-        values.put("domain", cookie.domain());
-        values.put("path", cookie.path());
-        return objectMapper.writeValueAsString(values);
-
-//        return new JSONObject(values).toString();
     }
 
     @Override

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/CollectorCookieJar.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/CollectorCookieJar.java
@@ -1,0 +1,59 @@
+package com.snowplowanalytics.snowplow.tracker.http;
+
+import okhttp3.Cookie;
+import okhttp3.HttpUrl;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CollectorCookieJar implements okhttp3.CookieJar {
+    private Set<CollectorCookie> cookies;
+
+    public CollectorCookieJar() {
+        cookies = Collections.newSetFromMap(new ConcurrentHashMap<CollectorCookie, Boolean>());
+    }
+
+    @Override
+    public List<Cookie> loadForRequest(HttpUrl url) {
+        List<CollectorCookie> cookiesToRemove = new ArrayList<>();
+        List<Cookie> validCookies = new ArrayList<>();
+
+        for (CollectorCookie currentCookie : cookies) {
+            if (currentCookie.isExpired()) {
+                cookiesToRemove.add(currentCookie);
+            } else if (currentCookie.getCookie().matches(url)) {
+                validCookies.add(currentCookie.getCookie());
+            }
+        }
+
+        if (!cookiesToRemove.isEmpty()) {
+            removeAll(cookiesToRemove);
+        }
+
+        return validCookies;
+    }
+
+    @Override
+    public void saveFromResponse(HttpUrl httpUrl, List<Cookie> cookies) {
+        saveAll(cookies);
+    }
+
+    public void clear() {
+        cookies.clear();
+    }
+
+    private void saveAll(Collection<Cookie> newCookies) {
+        for (CollectorCookie cookie : CollectorCookie.decorateAll(newCookies)) {
+            cookies.remove(cookie);
+            cookies.add(cookie);
+        }
+
+    }
+
+    private void removeAll(Collection<CollectorCookie> cookiesToRemove) {
+        for (CollectorCookie cookie : cookiesToRemove) {
+            cookies.remove(cookie);
+        }
+    }
+}
+

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/CollectorCookieJar.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/CollectorCookieJar.java
@@ -7,10 +7,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class CollectorCookieJar implements okhttp3.CookieJar {
-    private static final Set<CollectorCookie> cookies = Collections.newSetFromMap(new ConcurrentHashMap<CollectorCookie, Boolean>());
-
-    public CollectorCookieJar() {
-    }
+    private static final Set<CollectorCookie> cookies = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     @Override
     public List<Cookie> loadForRequest(HttpUrl url) {

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/CollectorCookieJar.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/CollectorCookieJar.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2014-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
 package com.snowplowanalytics.snowplow.tracker.http;
 
 import okhttp3.Cookie;

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/CollectorCookieJar.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/CollectorCookieJar.java
@@ -7,10 +7,9 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class CollectorCookieJar implements okhttp3.CookieJar {
-    private Set<CollectorCookie> cookies;
+    private static final Set<CollectorCookie> cookies = Collections.newSetFromMap(new ConcurrentHashMap<CollectorCookie, Boolean>());
 
     public CollectorCookieJar() {
-        cookies = Collections.newSetFromMap(new ConcurrentHashMap<CollectorCookie, Boolean>());
     }
 
     @Override

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/OkHttpClientAdapter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/OkHttpClientAdapter.java
@@ -37,24 +37,17 @@ public class OkHttpClientAdapter extends AbstractHttpClientAdapter {
     private static final Logger LOGGER = LoggerFactory.getLogger(OkHttpClientAdapter.class);
     private final MediaType JSON = MediaType.get(Constants.POST_CONTENT_TYPE);
     private OkHttpClient httpClient;
-    private CookieJar cookieJar = null; // Optional
 
     public static abstract class Builder<T extends Builder<T>> extends AbstractHttpClientAdapter.Builder<T> {
 
         private OkHttpClient httpClient; // Required
-        private CookieJar cookieJar; // Optional
 
         /**
-         * @param httpClient The Apache HTTP Client to use
+         * @param httpClient The OkHTTP Client to use
          * @return itself
          */
         public T httpClient(OkHttpClient httpClient) {
             this.httpClient = httpClient;
-            return self();
-        }
-
-        public T cookieJar(CookieJar cookieJar) {
-            this.cookieJar = cookieJar;
             return self();
         }
 
@@ -80,7 +73,6 @@ public class OkHttpClientAdapter extends AbstractHttpClientAdapter {
         // Precondition checks
         Preconditions.checkNotNull(builder.httpClient);
 
-        cookieJar = builder.cookieJar == null ? new CollectorCookieJar() : builder.cookieJar;
         httpClient = builder.httpClient;
     }
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/OkHttpClientAdapter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/OkHttpClientAdapter.java
@@ -19,11 +19,7 @@ import java.io.IOException;
 import com.google.common.base.Preconditions;
 
 // SquareUp
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.MediaType;
-import okhttp3.Response;
-import okhttp3.RequestBody;
+import okhttp3.*;
 
 // Slf4j
 import org.slf4j.Logger;
@@ -41,10 +37,12 @@ public class OkHttpClientAdapter extends AbstractHttpClientAdapter {
     private static final Logger LOGGER = LoggerFactory.getLogger(OkHttpClientAdapter.class);
     private final MediaType JSON = MediaType.get(Constants.POST_CONTENT_TYPE);
     private OkHttpClient httpClient;
+    private CookieJar cookieJar = null; // Optional
 
     public static abstract class Builder<T extends Builder<T>> extends AbstractHttpClientAdapter.Builder<T> {
 
         private OkHttpClient httpClient; // Required
+        private CookieJar cookieJar; // Optional
 
         /**
          * @param httpClient The Apache HTTP Client to use
@@ -52,6 +50,11 @@ public class OkHttpClientAdapter extends AbstractHttpClientAdapter {
          */
         public T httpClient(OkHttpClient httpClient) {
             this.httpClient = httpClient;
+            return self();
+        }
+
+        public T cookieJar(CookieJar cookieJar) {
+            this.cookieJar = cookieJar;
             return self();
         }
 
@@ -77,7 +80,8 @@ public class OkHttpClientAdapter extends AbstractHttpClientAdapter {
         // Precondition checks
         Preconditions.checkNotNull(builder.httpClient);
 
-        this.httpClient = builder.httpClient;
+        cookieJar = builder.cookieJar == null ? new CollectorCookieJar() : builder.cookieJar;
+        httpClient = builder.httpClient;
     }
 
     /**

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/CollectorCookieJarTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/CollectorCookieJarTest.java
@@ -12,15 +12,9 @@
  */
 package com.snowplowanalytics.snowplow.tracker.emitter;
 
-import com.snowplowanalytics.snowplow.tracker.DevicePlatform;
-import com.snowplowanalytics.snowplow.tracker.Tracker;
-import com.snowplowanalytics.snowplow.tracker.events.PageView;
-import com.snowplowanalytics.snowplow.tracker.events.ScreenView;
 import com.snowplowanalytics.snowplow.tracker.http.CollectorCookieJar;
-import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 import okhttp3.Cookie;
 import okhttp3.HttpUrl;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/CollectorCookieJarTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/CollectorCookieJarTest.java
@@ -18,7 +18,7 @@ import okhttp3.HttpUrl;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -28,7 +28,7 @@ public class CollectorCookieJarTest {
     String domain2 = "http://other.test.url.com";
     Cookie cookie1;
     CollectorCookieJar cookieJar;
-    ArrayList<Cookie> requestCookies;
+    List<Cookie> requestCookies;
 
     @Before
     public void setUp() {
@@ -38,18 +38,17 @@ public class CollectorCookieJarTest {
                 .domain("snowplow.test.url.com")
                 .build();
         cookieJar = new CollectorCookieJar();
-        requestCookies = new ArrayList<>();
     }
 
     @Test
     public void testNoCookiesAtStartup() {
-        List<Cookie> cookies1 = cookieJar.loadForRequest(HttpUrl.parse(domain1));
-        assertTrue(cookies1.isEmpty());
+        List<Cookie> cookies = cookieJar.loadForRequest(HttpUrl.parse(domain1));
+        assertTrue(cookies.isEmpty());
     }
 
     @Test
     public void testReturnsCookiesAfterSetInResponse() {
-        requestCookies.add(cookie1);
+        requestCookies = Collections.singletonList(cookie1);
         cookieJar.saveFromResponse(
                 HttpUrl.parse(domain1),
                 requestCookies
@@ -64,7 +63,7 @@ public class CollectorCookieJarTest {
 
     @Test
     public void testDoesntReturnCookiesForDifferentDomain() {
-        requestCookies.add(cookie1);
+        requestCookies = Collections.singletonList(cookie1);
         cookieJar.saveFromResponse(
                 HttpUrl.parse(domain1),
                 requestCookies
@@ -78,7 +77,7 @@ public class CollectorCookieJarTest {
 
     @Test
     public void testMaintainsCookiesAcrossJarInstances() {
-        requestCookies.add(cookie1);
+        requestCookies = Collections.singletonList(cookie1);
         cookieJar.saveFromResponse(
                 HttpUrl.parse(domain1),
                 requestCookies
@@ -93,7 +92,7 @@ public class CollectorCookieJarTest {
 
     @Test
     public void testClearsCookies() {
-        requestCookies.add(cookie1);
+        requestCookies = Collections.singletonList(cookie1);
         cookieJar.saveFromResponse(
                 HttpUrl.parse(domain1),
                 requestCookies
@@ -116,7 +115,7 @@ public class CollectorCookieJarTest {
                 .expiresAt(1654869235L)
                 .build();
 
-        requestCookies.add(cookie2);
+        requestCookies = Collections.singletonList(cookie2);
         cookieJar.saveFromResponse(
                 HttpUrl.parse(domain1),
                 requestCookies

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/CollectorCookieJarTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/CollectorCookieJarTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2014-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.tracker.emitter;
+
+import com.snowplowanalytics.snowplow.tracker.events.PageView;
+import com.snowplowanalytics.snowplow.tracker.http.CollectorCookieJar;
+import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
+import okhttp3.Cookie;
+import okhttp3.HttpUrl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class CollectorCookieJarTest {
+    String domain1 = "http://snowplow.test.url.com";
+    String domain2 = "http://other.test.url.com";
+    Cookie cookie1;
+    CollectorCookieJar cookieJar;
+    ArrayList<Cookie> requestCookies;
+
+    @Before
+    public void setUp() {
+        cookie1 = new Cookie.Builder()
+                .name("sp")
+                .value("xxx")
+                .domain("snowplow.test.url.com")
+                .build();
+        cookieJar = new CollectorCookieJar();
+        requestCookies = new ArrayList<>();
+    }
+
+    @Test
+    public void testNoCookiesAtStartup() {
+        List<Cookie> cookies1 = cookieJar.loadForRequest(HttpUrl.parse(domain1));
+        assertTrue(cookies1.isEmpty());
+    }
+
+    @Test
+    public void testReturnsCookiesAfterSetInResponse() {
+        requestCookies.add(cookie1);
+        cookieJar.saveFromResponse(
+                HttpUrl.parse(domain1),
+                requestCookies
+        );
+
+        List<Cookie> cookies2 = cookieJar.loadForRequest(HttpUrl.parse(domain1));
+        assertFalse(cookies2.isEmpty());
+        assertEquals(cookies2.get(0).name(), "sp");
+
+        cookieJar.clear();
+    }
+
+    @Test
+    public void testDoesntReturnCookiesForDifferentDomain() {
+        requestCookies.add(cookie1);
+        cookieJar.saveFromResponse(
+                HttpUrl.parse(domain1),
+                requestCookies
+        );
+
+        List<Cookie> cookies2 = cookieJar.loadForRequest(HttpUrl.parse(domain2));
+        assertTrue(cookies2.isEmpty());
+
+        cookieJar.clear();
+    }
+
+    @Test
+    public void testMaintainsCookiesAcrossJarInstances() {
+        requestCookies.add(cookie1);
+        cookieJar.saveFromResponse(
+                HttpUrl.parse("http://acme.test.url.com"),
+                requestCookies
+        );
+
+        CollectorCookieJar cookieJar2 = new CollectorCookieJar();
+
+        List<Cookie> cookies2 = cookieJar2.loadForRequest(HttpUrl.parse("http://acme.test.url.com"));
+        assertFalse(cookies2.isEmpty());
+
+        cookieJar.clear();
+    }
+
+//    @Test
+//    public void testRemovesInvalidCookies() {
+//        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+//        SharedPreferences sharedPreferences = context.getSharedPreferences(COOKIE_PERSISTANCE, Context.MODE_PRIVATE);
+//        sharedPreferences.edit().putString("x", "y").apply();
+//        assertEquals(1, sharedPreferences.getAll().size());
+//
+//        new CollectorCookieJar(context);
+//        assertEquals(0, sharedPreferences.getAll().size());
+//    }
+}

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/CollectorCookieJarTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/CollectorCookieJarTest.java
@@ -83,13 +83,12 @@ public class CollectorCookieJarTest {
     public void testMaintainsCookiesAcrossJarInstances() {
         requestCookies.add(cookie1);
         cookieJar.saveFromResponse(
-                HttpUrl.parse("http://acme.test.url.com"),
+                HttpUrl.parse(domain1),
                 requestCookies
         );
 
         CollectorCookieJar cookieJar2 = new CollectorCookieJar();
-
-        List<Cookie> cookies2 = cookieJar2.loadForRequest(HttpUrl.parse("http://acme.test.url.com"));
+        List<Cookie> cookies2 = cookieJar2.loadForRequest(HttpUrl.parse(domain1));
         assertFalse(cookies2.isEmpty());
 
         cookieJar.clear();


### PR DESCRIPTION
For issue #336.

This change brings a new feature of the Android tracker ([issue 519](https://github.com/snowplow/snowplow-android-tracker/issues/519)), released in v3.2.0 to the Java tracker. OkHTTP's CookieJar interface is used to store cookies from the event collector. The cookie can then be added to subsequent requests - the events will then all have the same `network_userid`.

There are some differences in implementation between Android and Java trackers. For Android, Shared Preferences is used to persistently store tracker state in the user's device. By storing cookies there too, they can be shared across instances of the CollectorCookieJar.

For the Java tracker, we currently only store things in memory. Cookies are stored in a static Set in memory here. Also, the architecture/naming around the HTTP clients is slightly different, e.g. Android has `NetworkConnection` while Java has `HttpClientAdapter`.