### PR TITLE
Rename Unstructured events to SelfDescribing (close #296)

### DIFF
--- a/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
+++ b/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
@@ -107,10 +107,10 @@ public class Main {
             .build();
 
 
-        // This is an example of a custom "Unstructured" event based on a schema
-        // Unstructured events are also called "self-describing" events
-        // because of their SelfDescribingJson base
-        Unstructured unstructured = Unstructured.builder()
+        // This is an example of a custom SelfDescribing event based on a schema
+        // SelfDescribing events used to be called "unstructured" events
+        // in comparison to Structured events. However, they are in fact more highly structured.
+        SelfDescribing selfDescribing = SelfDescribing.builder()
             .eventData(new SelfDescribingJson(
                     "iglu:com.snowplowanalytics.iglu/anything-a/jsonschema/1-0-0",
                     ImmutableMap.of("foo", "bar")
@@ -148,7 +148,7 @@ public class Main {
 
         tracker.track(pageViewEvent); // the .track method schedules the event for delivery to Snowplow
         tracker.track(ecommerceTransaction); // This will track two events
-        tracker.track(unstructured);
+        tracker.track(selfDescribing);
         tracker.track(screenView);
         tracker.track(timing);
         tracker.track(structured);

--- a/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
+++ b/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
@@ -108,8 +108,6 @@ public class Main {
 
 
         // This is an example of a custom SelfDescribing event based on a schema
-        // SelfDescribing events used to be called "unstructured" events
-        // in comparison to Structured events. However, they are in fact more highly structured.
         SelfDescribing selfDescribing = SelfDescribing.builder()
             .eventData(new SelfDescribingJson(
                     "iglu:com.snowplowanalytics.iglu/anything-a/jsonschema/1-0-0",
@@ -119,7 +117,7 @@ public class Main {
             .build();
 
 
-        // This is an example of a ScreenView event which will be translated into an Unstructured event
+        // This is an example of a ScreenView event which will be translated into a SelfDescribing event
         ScreenView screenView = ScreenView.builder()
             .name("name")
             .id("id")
@@ -127,7 +125,7 @@ public class Main {
             .build();
 
 
-        // This is an example of a Timing event which will be translated into an Unstructured event
+        // This is an example of a Timing event which will be translated into a SelfDescribing event
         Timing timing = Timing.builder()
             .category("category")
             .label("label")

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -248,11 +248,11 @@ public class Tracker {
         List<Event> eventList = new ArrayList<>();
         final Class<?> eventClass = event.getClass();
 
-        if (eventClass.equals(Unstructured.class)) {
-            // Need to set the Base64 rule for Unstructured events
-            final Unstructured unstructured = (Unstructured) event;
-            unstructured.setBase64Encode(parameters.getBase64Encoded());
-            eventList.add(unstructured);
+        if (eventClass.equals(SelfDescribing.class)) {
+            // Need to set the Base64 rule for SelfDescribing events
+            final SelfDescribing selfDescribing = (SelfDescribing) event;
+            selfDescribing.setBase64Encode(parameters.getBase64Encoded());
+            eventList.add(selfDescribing);
 
         } else if (eventClass.equals(EcommerceTransaction.class)) {
             final EcommerceTransaction ecommerceTransaction = (EcommerceTransaction) event;
@@ -262,17 +262,17 @@ public class Tracker {
             eventList.addAll(ecommerceTransaction.getItems());
 
         } else if (eventClass.equals(Timing.class) || eventClass.equals(ScreenView.class)) {
-            // Timing and ScreenView events are wrapper classes for Unstructured events
-            // Need to create Unstructured events from them to send.
-            final Unstructured unstructured = Unstructured.builder()
+            // Timing and ScreenView events are wrapper classes for SelfDescribing events
+            // Need to create SelfDescribing events from them to send.
+            final SelfDescribing selfDescribing = SelfDescribing.builder()
                     .eventData((SelfDescribingJson) event.getPayload())
                     .customContext(event.getContext())
                     .trueTimestamp(event.getTrueTimestamp())
                     .subject(event.getSubject())
                     .build();
 
-            unstructured.setBase64Encode(parameters.getBase64Encoded());
-            eventList.add(unstructured);
+            selfDescribing.setBase64Encode(parameters.getBase64Encoded());
+            eventList.add(selfDescribing);
 
         } else {
             eventList.add(event);

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/constants/Constants.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/constants/Constants.java
@@ -22,7 +22,7 @@ public class Constants {
 
     public static final String SCHEMA_PAYLOAD_DATA = "iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4";
     public static final String SCHEMA_CONTEXTS = "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1";
-    public static final String SCHEMA_UNSTRUCT_EVENT = "iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0";
+    public static final String SCHEMA_SELF_DESCRIBING_EVENT = "iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0";
     public static final String SCHEMA_SCREEN_VIEW = "iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0";
     public static final String SCHEMA_USER_TIMINGS = "iglu:com.snowplowanalytics.snowplow/timing/jsonschema/1-0-0";
 
@@ -30,7 +30,7 @@ public class Constants {
 
     public static final String EVENT_PAGE_VIEW = "pv";
     public static final String EVENT_STRUCTURED = "se";
-    public static final String EVENT_UNSTRUCTURED = "ue";
+    public static final String EVENT_SELF_DESCRIBING = "ue";
     public static final String EVENT_ECOMM = "tr";
     public static final String EVENT_ECOMM_ITEM = "ti";
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/constants/Parameter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/constants/Parameter.java
@@ -39,8 +39,8 @@ public class Parameter {
     public static final String UID = "uid";
     public static final String CONTEXT = "co";
     public static final String CONTEXT_ENCODED = "cx";
-    public static final String UNSTRUCTURED = "ue_pr";
-    public static final String UNSTRUCTURED_ENCODED = "ue_px";
+    public static final String SELF_DESCRIBING = "ue_pr";
+    public static final String SELF_DESCRIBING_ENCODED = "ue_px";
 
     // Subject class
     public static final String PLATFORM = "p";

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransaction.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransaction.java
@@ -29,7 +29,7 @@ import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
  * Constructs an EcommerceTransaction event object.
  * <p>
  * <b>Implementation note: </b><em>EcommerceTransaction/EcommerceTransactionItem uses a legacy design.
- * We aim to deprecate it eventually. We advise using Unstructured events instead, and attaching the items
+ * We aim to deprecate it eventually. We advise using SelfDescribing events instead, and attaching the items
  * as entities. </em>
  *
  * The specific items purchased in the transaction must be added as EcommerceTransactionItem objects.

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransactionItem.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransactionItem.java
@@ -25,7 +25,7 @@ import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
  * Constructs an EcommerceTransactionItem object.
  * <p>
  * <b>Implementation note: </b><em>EcommerceTransaction/EcommerceTransactionItem uses a legacy design.
- * We aim to deprecate it eventually. We advise using Unstructured events instead, and attaching the items
+ * We aim to deprecate it eventually. We advise using SelfDescribing events instead, and attaching the items
  * as entities. </em>
  *
  * EcommerceTransactionItems were designed for attaching data about purchased items to a

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/ScreenView.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/ScreenView.java
@@ -23,7 +23,7 @@ import java.util.LinkedHashMap;
 /**
  * Constructs a ScreenView event object.
  *
- * When tracked, generates an "unstructured" or "ue" event.
+ * When tracked, generates an "unstructured" or "ue" event (this was the old name for SelfDescribing events).
  */
 public class ScreenView extends AbstractEvent {
 
@@ -85,7 +85,7 @@ public class ScreenView extends AbstractEvent {
 
     /**
      * Return the payload wrapped into a SelfDescribingJson. When a ScreenView is tracked,
-     * the Tracker creates and tracks an Unstructured event from this SelfDescribingJson.
+     * the Tracker creates and tracks an SelfDescribing event from this SelfDescribingJson.
      *
      * @return the payload as a SelfDescribingJson.
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/ScreenView.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/ScreenView.java
@@ -23,7 +23,7 @@ import java.util.LinkedHashMap;
 /**
  * Constructs a ScreenView event object.
  *
- * When tracked, generates an "unstructured" or "ue" event (this was the old name for SelfDescribing events).
+ * When tracked, generates a SelfDescribing event (event type "ue").
  */
 public class ScreenView extends AbstractEvent {
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/SelfDescribing.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/SelfDescribing.java
@@ -22,14 +22,14 @@ import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
 
 /**
- * Constructs an Unstructured event object.
+ * Constructs a SelfDescribing event object.
  *
  * This is a customisable event type which allows you to track anything describable
  * by a JsonSchema.
  *
- * When tracked, generates an "unstructured" or "ue" event.
+ * When tracked, generates an "unstructured" or "ue" event (this was the old name for SelfDescribing events).
  */
-public class Unstructured extends AbstractEvent {
+public class SelfDescribing extends AbstractEvent {
 
     private final SelfDescribingJson eventData;
     private boolean base64Encode;
@@ -50,8 +50,8 @@ public class Unstructured extends AbstractEvent {
             return self();
         }
 
-        public Unstructured build() {
-            return new Unstructured(this);
+        public SelfDescribing build() {
+            return new SelfDescribing(this);
         }
     }
 
@@ -66,7 +66,7 @@ public class Unstructured extends AbstractEvent {
         return new Builder2();
     }
 
-    protected Unstructured(Builder<?> builder) {
+    protected SelfDescribing(Builder<?> builder) {
         super(builder);
 
         // Precondition checks

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/SelfDescribing.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/SelfDescribing.java
@@ -27,7 +27,7 @@ import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
  * This is a customisable event type which allows you to track anything describable
  * by a JsonSchema.
  *
- * When tracked, generates an "unstructured" or "ue" event (this was the old name for SelfDescribing events).
+ * When tracked, generates a self-describing event (event type "ue").
  */
 public class SelfDescribing extends AbstractEvent {
 
@@ -90,10 +90,10 @@ public class SelfDescribing extends AbstractEvent {
     public TrackerPayload getPayload() {
         TrackerPayload payload = new TrackerPayload();
         SelfDescribingJson envelope = new SelfDescribingJson(
-                Constants.SCHEMA_UNSTRUCT_EVENT, this.eventData.getMap());
-        payload.add(Parameter.EVENT, Constants.EVENT_UNSTRUCTURED);
+                Constants.SCHEMA_SELF_DESCRIBING_EVENT, this.eventData.getMap());
+        payload.add(Parameter.EVENT, Constants.EVENT_SELF_DESCRIBING);
         payload.addMap(envelope.getMap(), this.base64Encode,
-                Parameter.UNSTRUCTURED_ENCODED, Parameter.UNSTRUCTURED);
+                Parameter.SELF_DESCRIBING_ENCODED, Parameter.SELF_DESCRIBING);
         return putTrueTimestamp(payload);
     }
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Structured.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Structured.java
@@ -28,7 +28,7 @@ import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
  * To aid data quality and modeling, agree on business-wide definitions when designing
  * your tracking strategy.
  *
- * We recommend using Unstructured - fully custom - events instead.
+ * We recommend using SelfDescribing - fully custom - events instead.
  *
  * When tracked, generates a "struct" or "se" event.
  *

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Timing.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Timing.java
@@ -26,7 +26,7 @@ import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
 /**
  * Constructs a Timing event object.
  *
- * When tracked, generates an "unstructured" or "ue" event (this was the old name for SelfDescribing events).
+ * When tracked, generates a SelfDescribing event (event type "ue").
  */
 public class Timing extends AbstractEvent {
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Timing.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Timing.java
@@ -26,7 +26,7 @@ import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
 /**
  * Constructs a Timing event object.
  *
- * When tracked, generates an "unstructured" or "ue" event.
+ * When tracked, generates an "unstructured" or "ue" event (this was the old name for SelfDescribing events).
  */
 public class Timing extends AbstractEvent {
 
@@ -120,7 +120,7 @@ public class Timing extends AbstractEvent {
 
     /**
      * Return the payload wrapped into a SelfDescribingJson. When a Timing event is tracked,
-     * the Tracker creates and tracks an Unstructured event from this SelfDescribingJson.
+     * the Tracker creates and tracks a SelfDescribing event from this SelfDescribingJson.
      *
      * @return the payload as a SelfDescribingJson.
      */

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -68,7 +68,7 @@ public class TrackerTest {
     @Test
     public void testTrackReturnsEventIdIfSuccessful() throws InterruptedException {
         // a list to allow for eCommerceTransaction
-        List<String> result = tracker.track(Unstructured.builder()
+        List<String> result = tracker.track(SelfDescribing.builder()
                 .eventData(new SelfDescribingJson(
                         "iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0",
                         ImmutableMap.of("foo", "bar")
@@ -104,7 +104,7 @@ public class TrackerTest {
         FailingMockEmitter failingMockEmitter = new FailingMockEmitter();
         tracker = new Tracker.TrackerBuilder(failingMockEmitter, "AF003", "cloudfront").build();
 
-        List<String> result = tracker.track(Unstructured.builder()
+        List<String> result = tracker.track(SelfDescribing.builder()
                 .eventData(new SelfDescribingJson(
                         "iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0",
                         ImmutableMap.of("foo", "bar")
@@ -243,7 +243,7 @@ public class TrackerTest {
     @Test
     public void testUnstructuredEventWithContext() throws InterruptedException {
         // When
-        tracker.track(Unstructured.builder()
+        tracker.track(SelfDescribing.builder()
                 .eventData(new SelfDescribingJson(
                         "iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0",
                         ImmutableMap.of("foo", "bar")
@@ -274,7 +274,7 @@ public class TrackerTest {
     @Test
     public void testUnstructuredEventWithoutContext() throws InterruptedException {
         // When
-        tracker.track(Unstructured.builder()
+        tracker.track(SelfDescribing.builder()
                 .eventData(new SelfDescribingJson(
                         "iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0",
                         ImmutableMap.of("foo", "baær")
@@ -303,7 +303,7 @@ public class TrackerTest {
     @Test
     public void testUnstructuredEventWithoutTrueTimestamp() throws InterruptedException {
         // When
-        tracker.track(Unstructured.builder()
+        tracker.track(SelfDescribing.builder()
                 .eventData(new SelfDescribingJson(
                         "iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0",
                         ImmutableMap.of("foo", "bar")
@@ -375,7 +375,7 @@ public class TrackerTest {
                 .trueTimestamp(123456L)
                 .build());
 
-        tracker.track(Unstructured.builder()
+        tracker.track(SelfDescribing.builder()
                 .eventData(new SelfDescribingJson(
                         "iglu:com.snowplowanalytics.snowplow/example/jsonschema/1-0-0",
                         ImmutableMap.of("foo", "bar")

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -241,7 +241,7 @@ public class TrackerTest {
     }
 
     @Test
-    public void testUnstructuredEventWithContext() throws InterruptedException {
+    public void testSelfDescribingEventWithContext() throws InterruptedException {
         // When
         tracker.track(SelfDescribing.builder()
                 .eventData(new SelfDescribingJson(
@@ -272,7 +272,7 @@ public class TrackerTest {
     }
 
     @Test
-    public void testUnstructuredEventWithoutContext() throws InterruptedException {
+    public void testSelfDescribingEventWithoutContext() throws InterruptedException {
         // When
         tracker.track(SelfDescribing.builder()
                 .eventData(new SelfDescribingJson(
@@ -301,7 +301,7 @@ public class TrackerTest {
     }
 
     @Test
-    public void testUnstructuredEventWithoutTrueTimestamp() throws InterruptedException {
+    public void testSelfDescribingEventWithoutTrueTimestamp() throws InterruptedException {
         // When
         tracker.track(SelfDescribing.builder()
                 .eventData(new SelfDescribingJson(


### PR DESCRIPTION
For issue #296.

Replaces the legacy Unstructured name with the newer SelfDescribing, for consistency across the trackers.