### PR TITLE
Add a maximum wait time and jitter to event sending retry (close #338)

### DIFF
--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -340,7 +340,7 @@ public class BatchEmitter implements Emitter, Closeable {
 
                     // exponentially increase retry backoff time after the first failure, up to the maximum wait time
                     if (!retryDelay.compareAndSet(0, 100)) {
-                        retryDelay.getAndSet(calculateRetryDelay());
+                        retryDelay.updateAndGet(this::calculateRetryDelay);
                     }
                 }
             } catch (Exception e) {
@@ -370,8 +370,7 @@ public class BatchEmitter implements Emitter, Closeable {
         return new SelfDescribingJson(Constants.SCHEMA_PAYLOAD_DATA, toSendPayloads);
     }
 
-    private int calculateRetryDelay() {
-        int currentDelay = retryDelay.get();
+    private int calculateRetryDelay(int currentDelay) {
         double newDelay;
         double jitter = Math.random();
         int randomChoice = (Math.random() < 0.5) ? 0 : 1;

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -21,7 +21,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.common.base.Preconditions;
 import com.snowplowanalytics.snowplow.tracker.constants.Constants;

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
@@ -297,13 +297,17 @@ public class BatchEmitterTest {
                 .batchSize(1)
                 .build();
 
-        List<TrackerPayload> payloads = createPayloads(2);
-        for (TrackerPayload payload : payloads) {
-            emitter.add(payload);
-        }
+        emitter.add(createPayload());
         Thread.sleep(500);
 
-        Assert.assertEquals(100, emitter.getRetryDelay());
+        int firstDelay = emitter.getRetryDelay();
+        Assert.assertNotEquals(0, firstDelay);
+
+        emitter.add(createPayload());
+        Thread.sleep(500);
+
+        int secondDelay = emitter.getRetryDelay();
+        Assert.assertTrue(secondDelay > firstDelay);
     }
 
     @Test


### PR DESCRIPTION
For issue #338.

When requests are rejected by the collector, the events are returned to storage. A wait time is added before further attempts are made. The delay increases exponentially with every subsequent rejection. However, there was no maximum time.

This wait time now starts at 100ms, and exponentially increases up to 10 min. I also added randomness to avoid the collector being overwhelmed when it starts accepting requests again.