### PR TITLE
Restore Emitter callbacks for success and failure (close #339)

### DIFF
--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -13,11 +13,6 @@
 package com.snowplowanalytics.snowplow.tracker.emitter;
 
 import java.io.Closeable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -249,10 +249,21 @@ public class BatchEmitter implements Emitter, Closeable {
         retryDelay = new AtomicInteger(0);
         batchSize = builder.batchSize;
 
+        if (builder.callback != null) {
+            callback = builder.callback;
+        } else {
+            callback = new EmitterCallback() {
+                @Override
+                public void onSuccess(List<TrackerPayload> payloads) {}
+                @Override
+                public void onFailure(FailureType failureType, boolean willRetry, List<TrackerPayload> payloads) {}
+            };
+        }
+
         if (builder.eventStore != null) {
             eventStore = builder.eventStore;
         } else {
-            eventStore = new InMemoryEventStore(builder.bufferCapacity);
+            eventStore = new InMemoryEventStore(callback, builder.bufferCapacity);
         }
 
         if (builder.fatalResponseCodes != null) {
@@ -267,16 +278,6 @@ public class BatchEmitter implements Emitter, Closeable {
             executor = Executors.newScheduledThreadPool(builder.threadCount, new EmitterThreadFactory());
         }
 
-        if (builder.callback != null) {
-            callback = builder.callback;
-        } else {
-            callback = new EmitterCallback() {
-                @Override
-                public void onSuccess(List<TrackerPayload> payloads) {}
-                @Override
-                public void onFailure(FailureType failureType, boolean willRetry, List<TrackerPayload> payloads) {}
-            };
-        }
     }
 
     /**

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/EmitterCallback.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/EmitterCallback.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2014-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.tracker.emitter;
+
+import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
+
+import java.util.List;
+
+/**
+ * This interface allows the user to provide callbacks for when events are
+ * successfully sent to the event collector, or at other times when data loss
+ * may occur, specified using the FailureType enum.
+ */
+public interface EmitterCallback {
+    void onSuccess(List<TrackerPayload> payloads);
+
+    void onFailure(FailureType failureType, boolean willRetry, List<TrackerPayload> payloads);
+}

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/EventStore.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/EventStore.java
@@ -50,7 +50,7 @@ public interface EventStore {
      * @param needRetry if another attempt should be made to send the events
      * @param batchId the ID of the batch of events
      */
-    void cleanupAfterSendingAttempt(boolean needRetry, long batchId);
+    List<TrackerPayload> cleanupAfterSendingAttempt(boolean needRetry, long batchId);
 
     /**
      * Get the current size of the buffer.

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/FailureType.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/FailureType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2014-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.tracker.emitter;
+
+/**
+ * The supported failure options for EmitterCallback.
+ */
+public enum FailureType {
+    CONNECTION_FAILURE,
+    REJECTED_BY_COLLECTOR,
+    TRACKER_STORAGE_FULL
+}

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/FailureType.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/FailureType.java
@@ -16,7 +16,29 @@ package com.snowplowanalytics.snowplow.tracker.emitter;
  * The supported failure options for EmitterCallback.
  */
 public enum FailureType {
-    CONNECTION_FAILURE,
+    /**
+     * A request status code other than 2xx is received. Payloads in the request
+     * may be automatically retried or not following this kind of failure, depending on the status code
+     * and the BatchEmitter configuration.
+     */
     REJECTED_BY_COLLECTOR,
-    TRACKER_STORAGE_FULL
+
+    /**
+     * The InMemoryEventStore buffer is full. This could occur if the network connection
+     * to the event collector is down, causing payloads to accumulate in the buffer.
+     * This failure can occur either when the Tracker attempts to add new events to the BatchEmitter,
+     * or when events that need to be retried are returned to the buffer, removing newer events
+     * to make space if necessary.
+     */
+    TRACKER_STORAGE_FULL,
+
+    /**
+     * An exception or unsuccessful POST request in OkHttpClientAdapter.
+     */
+    HTTP_CONNECTION_FAILURE,
+
+    /**
+     * An exception during POST request in BatchEmitter.
+     */
+    EMITTER_REQUEST_FAILURE
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStore.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStore.java
@@ -131,9 +131,10 @@ public class InMemoryEventStore implements EventStore {
      * @param batchId the ID of the batch of events
      */
     @Override
-    public void cleanupAfterSendingAttempt(boolean needRetry, long batchId) {
+    public List<TrackerPayload> cleanupAfterSendingAttempt(boolean needRetry, long batchId) {
         // Events that successfully sent are deleted from the pending buffer
         List<TrackerPayload> events = eventsBeingSent.remove(batchId);
+        List<TrackerPayload> removedEvents = new ArrayList<>();
 
         // Events that didn't send are inserted at the head of the eventBuffer
         // for immediate resending.
@@ -149,6 +150,7 @@ public class InMemoryEventStore implements EventStore {
                 }
             }
         }
+        return removedEvents;
     }
 
     /**

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
@@ -425,9 +425,6 @@ public class BatchEmitterTest {
 
     @Test
     public void callsFailureCallbackWhenRejectedNoRetry() throws InterruptedException {
-        List<Integer> noRetry = new ArrayList<>();
-        noRetry.add(403);
-
         class TestCallback implements EmitterCallback {
             boolean willRetry;
             List<TrackerPayload> payloads;
@@ -450,7 +447,6 @@ public class BatchEmitterTest {
                 .httpClientAdapter(new MockHttpClientAdapter(403))
                 .batchSize(1)
                 .callback(callback)
-                .fatalResponseCodes(noRetry)
                 .build();
 
         TrackerPayload payload = createPayload();

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStoreTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStoreTest.java
@@ -111,44 +111,6 @@ public class InMemoryEventStoreTest {
         Assert.assertTrue(eventStore.getAllEvents().contains(differentPayload));
     }
 
-    @Test
-    public void callFailureCallbackIfDropEvents() {
-        class TestCallback implements EmitterCallback {
-            boolean willRetry;
-            List<TrackerPayload> payloads;
-            FailureType failureType;
-
-            @Override
-            public void onSuccess(List<TrackerPayload> payloads) {
-            }
-
-            @Override
-            public void onFailure(FailureType failureType, boolean willRetry, List<TrackerPayload> payloads) {
-                this.failureType = failureType;
-                this.willRetry = willRetry;
-                this.payloads = payloads;
-            }
-        };
-
-        TestCallback callback = new TestCallback();
-        eventStore = new InMemoryEventStore(callback, 3);
-
-        TrackerPayload differentPayload = createTrackerPayload();
-
-        eventStore.addEvent(differentPayload);
-        eventStore.getEventsBatch(1);
-
-        eventStore.addEvent(trackerPayload);
-        eventStore.addEvent(trackerPayload);
-        eventStore.addEvent(trackerPayload);
-
-        eventStore.cleanupAfterSendingAttempt(true, 1L);
-
-        Assert.assertEquals(FailureType.TRACKER_STORAGE_FULL, callback.failureType);
-        Assert.assertFalse(callback.willRetry);
-        Assert.assertEquals(callback.payloads.get(0), trackerPayload);
-    }
-
     private TrackerPayload createTrackerPayload() {
         PageView pv = PageView.builder()
                 .pageUrl("https://www.snowplowanalytics.com/")

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStoreTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/InMemoryEventStoreTest.java
@@ -18,8 +18,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.List;
-
 public class InMemoryEventStoreTest {
 
     private TrackerPayload trackerPayload;


### PR DESCRIPTION
For issue #339.

Allows users to provide callbacks to `BatchEmitter`. The success callback will be called after a request is successfully sent. The failure callback will be called after a request gets a response code other than 2xx, or if the emitter's storage is full.

A new EmitterCallback interface is provided for the callbacks, along with a new enum, FailureType, for the failure callback. The three possible failures are: `CONNECTION_FAILURE` (exceptions during event sending); `REJECTED_BY_COLLECTOR` (non-2xx HTML request codes); or `TRACKER_STORAGE_FULL`.

Events are added to the storage in two places, therefore the `TRACKER_STORAGE_FULL` can occur in two places. The standard occasion is when new events are added to the `BatchEmitter` by the `Tracker` object. However, if events fail to send and should be retried, they are added back into the storage queue inside the `InMemoryEventStore`. If the queue is full, newer events are removed and deleted to make space for the returning older events.

This means that the EmitterCallback should be shared across `BatchEmitter` and `InMemoryEventStore`. I added a Builder to `InMemoryEventStore` to avoid having a confusing collection of constructors.