### PR TITLE
Standardise API for Tracker and Subject Builders (close #302) 

### DIFF
--- a/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
+++ b/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
@@ -49,7 +49,7 @@ public class Main {
                 .build();
 
         // now we have the emitter, we need a tracker to turn our events into something a Snowplow collector can understand
-        final Tracker tracker = new Tracker.TrackerBuilder(emitter, namespace, appId)
+        final Tracker tracker = Tracker.builder(emitter, namespace, appId)
             .base64(true)
             .platform(DevicePlatform.ServerSideApp)
             .build();
@@ -64,7 +64,7 @@ public class Main {
                 Collections.singletonMap("foo", "bar")));
 
         // This is an example of a eventSubject for adding user data
-        Subject eventSubject = new Subject.SubjectBuilder().build();
+        Subject eventSubject = Subject.builder().build();
         eventSubject.setUserId("example@snowplowanalytics.com");
         eventSubject.setLanguage("EN");
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 // This library
 import com.snowplowanalytics.snowplow.tracker.constants.Parameter;
+import com.snowplowanalytics.snowplow.tracker.emitter.Emitter;
 
 /**
  * An object for managing extra event decoration.
@@ -53,6 +54,10 @@ public class Subject {
      */
     public Subject(Subject subject){
       this.standardPairs.putAll(subject.getSubject());
+    }
+
+    public static SubjectBuilder builder() {
+        return new SubjectBuilder();
     }
 
     /**

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
@@ -18,7 +18,6 @@ import java.util.Map;
 
 // This library
 import com.snowplowanalytics.snowplow.tracker.constants.Parameter;
-import com.snowplowanalytics.snowplow.tracker.emitter.Emitter;
 
 /**
  * An object for managing extra event decoration.

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -55,6 +55,10 @@ public class Tracker {
 
     }
 
+    public static TrackerBuilder builder(Emitter emitter, String namespace, String appId) {
+        return new TrackerBuilder(emitter, namespace, appId);
+    }
+
     /**
      * Builder for the Tracker
      */

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
@@ -24,84 +24,84 @@ public class SubjectTest {
 
     @Test
     public void testSetUserId() {
-        Subject subject = new Subject.SubjectBuilder().build();
+        Subject subject = Subject.builder().build();
         subject.setUserId("user1");
         assertEquals("user1", subject.getSubject().get("uid"));
     }
 
     @Test
     public void testSetScreenResolution() {
-        Subject subject = new Subject.SubjectBuilder().build();
+        Subject subject = Subject.builder().build();
         subject.setScreenResolution(100, 150);
         assertEquals("100x150", subject.getSubject().get("res"));
     }
 
     @Test
     public void testSetViewPort() {
-        Subject subject = new Subject.SubjectBuilder().build();
+        Subject subject = Subject.builder().build();
         subject.setViewPort(150, 100);
         assertEquals("150x100", subject.getSubject().get("vp"));
     }
 
     @Test
     public void testSetColorDepth() {
-        Subject subject = new Subject.SubjectBuilder().build();
+        Subject subject = Subject.builder().build();
         subject.setColorDepth(10);
         assertEquals("10", subject.getSubject().get("cd"));
     }
 
     @Test
     public void testSetTimezone2() {
-        Subject subject = new Subject.SubjectBuilder().build();
+        Subject subject = Subject.builder().build();
         subject.setTimezone("America/Toronto");
         assertEquals("America/Toronto", subject.getSubject().get("tz"));
     }
 
     @Test
     public void testSetLanguage() {
-        Subject subject = new Subject.SubjectBuilder().build();
+        Subject subject = Subject.builder().build();
         subject.setLanguage("EN");
         assertEquals("EN", subject.getSubject().get("lang"));
     }
 
     @Test
     public void testSetIpAddress() {
-        Subject subject = new Subject.SubjectBuilder().build();
+        Subject subject = Subject.builder().build();
         subject.setIpAddress("127.0.0.1");
         assertEquals("127.0.0.1", subject.getSubject().get("ip"));
     }
 
     @Test
     public void testSetUseragent() {
-        Subject subject = new Subject.SubjectBuilder().build();
+        Subject subject = Subject.builder().build();
         subject.setUseragent("useragent");
         assertEquals("useragent", subject.getSubject().get("ua"));
     }
 
     @Test
     public void testSetDomainUserId() {
-        Subject subject = new Subject.SubjectBuilder().build();
+        Subject subject = Subject.builder().build();
         subject.setDomainUserId("duid");
         assertEquals("duid", subject.getSubject().get("duid"));
     }
 
     @Test
     public void testSetNetworkUserId() {
-        Subject subject = new Subject.SubjectBuilder().build();
+        Subject subject = Subject.builder().build();
         subject.setNetworkUserId("nuid");
         assertEquals("nuid", subject.getSubject().get("tnuid"));
     }
 
     @Test
     public void testSetDomainSessionId() {
-        Subject subject = new Subject.SubjectBuilder().build();
+        Subject subject = Subject.builder().build();
         subject.setDomainSessionId("sessionid");
         assertEquals("sessionid", subject.getSubject().get("sid"));
     }
 
     @Test
     public void testGetSubject() {
-        Subject subject = new Subject.SubjectBuilder().build();
+        Subject subject = Subject.builder().build();
         Map<String, String> expected = new HashMap<>();
         subject.setTimezone("America/Toronto");
         subject.setUserId("user1");

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -54,7 +54,7 @@ public class TrackerTest {
     public void setUp() {
         mockEmitter = new MockEmitter();
         tracker = Tracker.builder(mockEmitter, "AF003", "cloudfront")
-                .subject(new Subject.SubjectBuilder().build())
+                .subject(Subject.builder().build())
                 .base64(false)
                 .build();
         tracker.getSubject().setTimezone("Etc/UTC");
@@ -321,8 +321,8 @@ public class TrackerTest {
 
     @Test
     public void testTrackPageView() throws InterruptedException {
-        tracker = new Tracker.TrackerBuilder(mockEmitter, "AF003", "cloudfront")
-                .subject(new Subject.SubjectBuilder().build())
+        tracker = Tracker.builder(mockEmitter, "AF003", "cloudfront")
+                .subject(Subject.builder().build())
                 .base64(false)
                 .build();
         tracker.getSubject().setTimezone("Etc/UTC");
@@ -524,7 +524,7 @@ public class TrackerTest {
     @Test
     public void testTrackTimingWithSubject() throws InterruptedException {
         // Make Subject
-        Subject s1 = new Subject.SubjectBuilder().build();
+        Subject s1 = Subject.builder().build();
         s1.setIpAddress("127.0.0.1");
         s1.setTimezone("Etc/UTC");
 
@@ -563,13 +563,13 @@ public class TrackerTest {
 
     @Test
     public void testGetTrackerVersion() {
-        Tracker tracker = new Tracker.TrackerBuilder(mockEmitter, "namespace", "an-app-id").build();
+        Tracker tracker = Tracker.builder(mockEmitter, "namespace", "an-app-id").build();
         assertEquals("java-0.12.2", tracker.getTrackerVersion());
     }
 
     @Test
     public void testSetDefaultPlatform() {
-        Tracker tracker = new Tracker.TrackerBuilder(mockEmitter, "AF003", "cloudfront")
+        Tracker tracker = Tracker.builder(mockEmitter, "AF003", "cloudfront")
                 .platform(DevicePlatform.Desktop)
                 .build();
         assertEquals(DevicePlatform.Desktop, tracker.getPlatform());
@@ -580,13 +580,13 @@ public class TrackerTest {
         // Subject objects always have timezone set
         TimeZone.setDefault(TimeZone.getTimeZone("Etc/UTC"));
 
-        Subject s1 = new Subject.SubjectBuilder().build();
+        Subject s1 = Subject.builder().build();
         s1.setLanguage("EN");
-        Tracker tracker = new Tracker.TrackerBuilder(mockEmitter, "AF003", "cloudfront")
+        Tracker tracker = Tracker.builder(mockEmitter, "AF003", "cloudfront")
                 .subject(s1)
                 .build();
 
-        Subject s2 = new Subject.SubjectBuilder().build();
+        Subject s2 = Subject.builder().build();
         s2.setColorDepth(24);
         tracker.setSubject(s2);
 
@@ -599,7 +599,7 @@ public class TrackerTest {
 
     @Test
     public void testSetBase64Encoded() {
-        Tracker tracker = new Tracker.TrackerBuilder(mockEmitter, "AF003", "cloudfront")
+        Tracker tracker = Tracker.builder(mockEmitter, "AF003", "cloudfront")
                 .base64(false)
                 .build();
         assertFalse(tracker.getBase64Encoded());
@@ -607,13 +607,13 @@ public class TrackerTest {
 
     @Test
     public void testSetAppId() {
-        Tracker tracker = new Tracker.TrackerBuilder(mockEmitter, "AF003", "an-app-id").build();
+        Tracker tracker = Tracker.builder(mockEmitter, "AF003", "an-app-id").build();
         assertEquals("an-app-id", tracker.getAppId());
     }
 
     @Test
     public void testSetNamespace() {
-        Tracker tracker = new Tracker.TrackerBuilder(mockEmitter, "namespace", "an-app-id").build();
+        Tracker tracker = Tracker.builder(mockEmitter, "namespace", "an-app-id").build();
         assertEquals("namespace", tracker.getNamespace());
     }
 }

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -53,7 +53,7 @@ public class TrackerTest {
     @Before
     public void setUp() {
         mockEmitter = new MockEmitter();
-        tracker = new Tracker.TrackerBuilder(mockEmitter, "AF003", "cloudfront")
+        tracker = Tracker.builder(mockEmitter, "AF003", "cloudfront")
                 .subject(new Subject.SubjectBuilder().build())
                 .base64(false)
                 .build();
@@ -100,7 +100,7 @@ public class TrackerTest {
             public List<TrackerPayload> getBuffer() { return null; }
         }
         FailingMockEmitter failingMockEmitter = new FailingMockEmitter();
-        tracker = new Tracker.TrackerBuilder(failingMockEmitter, "AF003", "cloudfront").build();
+        tracker = Tracker.builder(failingMockEmitter, "AF003", "cloudfront").build();
 
         List<String> result = tracker.track(SelfDescribing.builder()
                 .eventData(new SelfDescribingJson(


### PR DESCRIPTION
For issue #302.

Standardise the API for constructing new `Tracker` and `Subject` objects. The new API - `Subject.builder().build()` is consistent with that of `Event` and `BatchEmitter` objects.

The old API - `new Subject.SubjectBuilder().build()` still works! It's not a breaking change.