### PR TITLE
Add a Snowplow interface with the ability to initialize and manage multiple trackers (close #340)

### DIFF
--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
@@ -17,7 +17,6 @@ import com.snowplowanalytics.snowplow.tracker.configuration.NetworkConfiguration
 import com.snowplowanalytics.snowplow.tracker.configuration.SubjectConfiguration;
 import com.snowplowanalytics.snowplow.tracker.configuration.TrackerConfiguration;
 import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
-import com.snowplowanalytics.snowplow.tracker.emitter.Emitter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,18 +26,61 @@ public class Snowplow {
     private static final Map<String, Tracker> trackers = new HashMap<>();
     private static Tracker defaultTracker;
 
+    /**
+     * @return the stored Trackers (the key is the tracker namespace)
+     */
     public static Map<String, Tracker> getTrackers() {
         return trackers;
     }
 
+    /**
+     * @return the default Tracker, or null if no default is set
+     */
     public static Tracker getDefaultTracker() {
         return defaultTracker;
     }
 
+    /**
+     * Set a specific Tracker instance as the default tracker. The Tracker will be added to the Snowplow class if its
+     * namespace is not already stored.
+     *
+     * The first Tracker created using createTracker() or registered with registerTracker()
+     * will automatically be the default tracker; this method is intended for use
+     * with multiple trackers.
+     *
+     * @param tracker the tracker to use as default
+     */
     public static void setDefaultTracker(Tracker tracker) {
+        if (!trackers.containsKey(tracker.getNamespace())) {
+            Snowplow.registerTracker(tracker);
+        }
+
         defaultTracker = tracker;
     }
 
+    /**
+     * Set a registered Tracker as the default tracker, using its namespace.
+     *
+     * @param namespace the namespace of the tracker to set as default
+     * @return true if the tracker was found and set
+     */
+    public static boolean setDefaultTracker(String namespace) {
+        if (trackers.containsKey(namespace)) {
+            defaultTracker = trackers.get(namespace);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Create a Snowplow tracker by providing three parameters.
+     *
+     * @param collectorUrl collector endpoint
+     * @param namespace unique identifier for the Tracker instance
+     * @param appId application ID
+     * @return the created Tracker
+     */
     public static Tracker createTracker(String collectorUrl, String namespace, String appId) {
         BatchEmitter emitter = BatchEmitter.builder().url(collectorUrl).build();
         Tracker tracker = new Tracker.TrackerBuilder(emitter, namespace, appId).build();
@@ -46,6 +88,15 @@ public class Snowplow {
         return tracker;
     }
 
+    /**
+     * Create a Snowplow tracker using Configuration objects.
+     *
+     * @param trackerConfig a TrackerConfiguration
+     * @param networkConfig a NetworkConfiguration
+     * @param emitterConfig an EmitterConfiguration
+     * @param subjectConfig a SubjectConfiguration
+     * @return the created Tracker
+     */
     public static Tracker createTracker(TrackerConfiguration trackerConfig,
                                         NetworkConfiguration networkConfig,
                                         EmitterConfiguration emitterConfig,
@@ -57,23 +108,51 @@ public class Snowplow {
         return tracker;
     }
 
+    /**
+     * Create a Snowplow tracker using Configuration objects.
+     *
+     * @param trackerConfig a TrackerConfiguration
+     * @param networkConfig a NetworkConfiguration
+     * @param emitterConfig an EmitterConfiguration
+     * @return the created Tracker
+     */
     public static Tracker createTracker(TrackerConfiguration trackerConfig,
                                         NetworkConfiguration networkConfig,
                                         EmitterConfiguration emitterConfig) {
         return createTracker(trackerConfig, networkConfig, emitterConfig, new SubjectConfiguration());
     }
 
+    /**
+     * Create a Snowplow tracker using Configuration objects.
+     *
+     * @param trackerConfig a TrackerConfiguration
+     * @param networkConfig a NetworkConfiguration
+     * @return the created Tracker
+     */
     public static Tracker createTracker(TrackerConfiguration trackerConfig,
                                         NetworkConfiguration networkConfig) {
         return createTracker(trackerConfig, networkConfig, new EmitterConfiguration(), new SubjectConfiguration());
     }
 
+    /**
+     * Create a Snowplow tracker using Configuration objects.
+     *
+     * @param trackerConfig a TrackerConfiguration
+     * @param networkConfig a NetworkConfiguration
+     * @param subjectConfig a SubjectConfiguration
+     * @return the created Tracker
+     */
     public static Tracker createTracker(TrackerConfiguration trackerConfig,
                                         NetworkConfiguration networkConfig,
                                         SubjectConfiguration subjectConfig) {
         return createTracker(trackerConfig, networkConfig, new EmitterConfiguration(), subjectConfig);
     }
 
+    /**
+     * Register a Tracker instance that was created manually, not via the Snowplow.createTracker() method.
+     *
+     * @param tracker a Tracker instance
+     */
     public static void registerTracker(Tracker tracker) {
         String namespace = tracker.getNamespace();
         if (trackers.containsKey(namespace)) {
@@ -87,10 +166,22 @@ public class Snowplow {
         }
     }
 
+    /**
+     * Get a Tracker by its namespace
+     *
+     * @param namespace the namespace of the tracker to retrieve
+     * @return the retrieved tracker
+     */
     public static Tracker getTracker(String namespace) {
         return trackers.get(namespace);
     }
 
+    /**
+     * Unregister a Tracker, using its namespace.
+     *
+     * @param namespace the namespace of the tracker to remove
+     * @return true if the tracker was found and removed
+     */
     public static boolean removeTracker(String namespace) {
         Tracker removedTracker = trackers.remove(namespace);
         if ((defaultTracker != null) && defaultTracker.getNamespace().equals(namespace)) {
@@ -99,10 +190,19 @@ public class Snowplow {
         return removedTracker != null;
     }
 
+    /**
+     * Unregister a Tracker.
+     *
+     * @param tracker the tracker to remove
+     * @return true if the tracker was found and removed
+     */
     public static boolean removeTracker(Tracker tracker) {
         return removeTracker(tracker.getNamespace());
     }
 
+    /**
+     * Clear (unregister) all trackers.
+     */
     public static void reset() {
         trackers.clear();
         defaultTracker = null;

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
@@ -97,12 +97,12 @@ public class Snowplow {
     /**
      * Create a Snowplow tracker with default configuration by providing three parameters.
      *
-     * @param collectorUrl collector endpoint
      * @param namespace unique identifier for the Tracker instance
+     * @param collectorUrl collector endpoint
      * @param appId application ID
      * @return the created Tracker
      */
-    public static Tracker createTracker(String collectorUrl, String namespace, String appId) {
+    public static Tracker createTracker(String namespace, String collectorUrl, String appId) {
         TrackerConfiguration trackerConfig = new TrackerConfiguration(namespace, appId);
         NetworkConfiguration networkConfig = new NetworkConfiguration(collectorUrl);
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
@@ -74,7 +74,7 @@ public class Snowplow {
     }
 
     /**
-     * Create a Snowplow tracker by providing three parameters.
+     * Create a Snowplow tracker with default configuration by providing three parameters.
      *
      * @param collectorUrl collector endpoint
      * @param namespace unique identifier for the Tracker instance
@@ -92,8 +92,8 @@ public class Snowplow {
      * Create a Snowplow tracker using Configuration objects.
      *
      * @param trackerConfig a TrackerConfiguration
-     * @param networkConfig a NetworkConfiguration
-     * @param emitterConfig an EmitterConfiguration
+     * @param networkConfig a NetworkConfiguration (will be used to create an OkHttpClientAdapter)
+     * @param emitterConfig an EmitterConfiguration (will be used to create a BatchEmitter)
      * @param subjectConfig a SubjectConfiguration
      * @return the created Tracker
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
@@ -106,7 +106,7 @@ public class Snowplow {
         TrackerConfiguration trackerConfig = new TrackerConfiguration(namespace, appId);
         NetworkConfiguration networkConfig = new NetworkConfiguration(collectorUrl);
 
-        return createTracker(trackerConfig, networkConfig, new EmitterConfiguration(), new SubjectConfiguration());
+        return createTracker(trackerConfig, networkConfig, new EmitterConfiguration(), null);
     }
 
     /**
@@ -120,7 +120,7 @@ public class Snowplow {
     public static Tracker createTracker(TrackerConfiguration trackerConfig,
                                         NetworkConfiguration networkConfig,
                                         EmitterConfiguration emitterConfig) {
-        return createTracker(trackerConfig, networkConfig, emitterConfig, new SubjectConfiguration());
+        return createTracker(trackerConfig, networkConfig, emitterConfig, null);
     }
 
     /**
@@ -132,7 +132,7 @@ public class Snowplow {
      */
     public static Tracker createTracker(TrackerConfiguration trackerConfig,
                                         NetworkConfiguration networkConfig) {
-        return createTracker(trackerConfig, networkConfig, new EmitterConfiguration(), new SubjectConfiguration());
+        return createTracker(trackerConfig, networkConfig, new EmitterConfiguration(), null);
     }
 
     /**

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
@@ -12,7 +12,11 @@
  */
 package com.snowplowanalytics.snowplow.tracker;
 
+import com.snowplowanalytics.snowplow.tracker.configuration.EmitterConfiguration;
+import com.snowplowanalytics.snowplow.tracker.configuration.NetworkConfiguration;
+import com.snowplowanalytics.snowplow.tracker.configuration.TrackerConfiguration;
 import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
+import com.snowplowanalytics.snowplow.tracker.emitter.Emitter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,6 +44,10 @@ public class Snowplow {
         registerTracker(tracker);
         return tracker;
     }
+
+//    public static Tracker createTracker(TrackerConfiguration trackerConfig, EmitterConfiguration emitterConfig, NetworkConfiguration networkConfig) {
+//
+//    }
 
     public static void registerTracker(Tracker tracker) {
         String namespace = tracker.getNamespace();

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
@@ -20,6 +20,7 @@ import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class Snowplow {
 
@@ -27,10 +28,10 @@ public class Snowplow {
     private static Tracker defaultTracker;
 
     /**
-     * @return the stored Trackers (the key is the tracker namespace)
+     * @return the stored tracker namespaces
      */
-    public static Map<String, Tracker> getTrackers() {
-        return trackers;
+    public static Set<String> getInstancedTrackerNamespaces() {
+        return trackers.keySet();
     }
 
     /**

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
@@ -14,6 +14,7 @@ package com.snowplowanalytics.snowplow.tracker;
 
 import com.snowplowanalytics.snowplow.tracker.configuration.EmitterConfiguration;
 import com.snowplowanalytics.snowplow.tracker.configuration.NetworkConfiguration;
+import com.snowplowanalytics.snowplow.tracker.configuration.SubjectConfiguration;
 import com.snowplowanalytics.snowplow.tracker.configuration.TrackerConfiguration;
 import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
 import com.snowplowanalytics.snowplow.tracker.emitter.Emitter;
@@ -45,9 +46,33 @@ public class Snowplow {
         return tracker;
     }
 
-//    public static Tracker createTracker(TrackerConfiguration trackerConfig, EmitterConfiguration emitterConfig, NetworkConfiguration networkConfig) {
-//
-//    }
+    public static Tracker createTracker(TrackerConfiguration trackerConfig,
+                                        NetworkConfiguration networkConfig,
+                                        EmitterConfiguration emitterConfig,
+                                        SubjectConfiguration subjectConfig) {
+        BatchEmitter emitter = new BatchEmitter(networkConfig, emitterConfig);
+        Subject subject = new Subject(subjectConfig);
+        Tracker tracker =  new Tracker(trackerConfig, emitter, subject);
+        registerTracker(tracker);
+        return tracker;
+    }
+
+    public static Tracker createTracker(TrackerConfiguration trackerConfig,
+                                        NetworkConfiguration networkConfig,
+                                        EmitterConfiguration emitterConfig) {
+        return createTracker(trackerConfig, networkConfig, emitterConfig, new SubjectConfiguration());
+    }
+
+    public static Tracker createTracker(TrackerConfiguration trackerConfig,
+                                        NetworkConfiguration networkConfig) {
+        return createTracker(trackerConfig, networkConfig, new EmitterConfiguration(), new SubjectConfiguration());
+    }
+
+    public static Tracker createTracker(TrackerConfiguration trackerConfig,
+                                        NetworkConfiguration networkConfig,
+                                        SubjectConfiguration subjectConfig) {
+        return createTracker(trackerConfig, networkConfig, new EmitterConfiguration(), subjectConfig);
+    }
 
     public static void registerTracker(Tracker tracker) {
         String namespace = tracker.getNamespace();

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
@@ -87,8 +87,12 @@ public class Snowplow {
                                         NetworkConfiguration networkConfig,
                                         EmitterConfiguration emitterConfig,
                                         SubjectConfiguration subjectConfig) {
+        Subject subject = null;
+        if (subjectConfig != null) {
+            subject = new Subject(subjectConfig);
+        }
+
         BatchEmitter emitter = new BatchEmitter(networkConfig, emitterConfig);
-        Subject subject = new Subject(subjectConfig);
         Tracker tracker =  new Tracker(trackerConfig, emitter, subject);
         registerTracker(tracker);
         return tracker;

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
@@ -75,21 +75,6 @@ public class Snowplow {
     }
 
     /**
-     * Create a Snowplow tracker with default configuration by providing three parameters.
-     *
-     * @param collectorUrl collector endpoint
-     * @param namespace unique identifier for the Tracker instance
-     * @param appId application ID
-     * @return the created Tracker
-     */
-    public static Tracker createTracker(String collectorUrl, String namespace, String appId) {
-        BatchEmitter emitter = BatchEmitter.builder().url(collectorUrl).build();
-        Tracker tracker = new Tracker.TrackerBuilder(emitter, namespace, appId).build();
-        registerTracker(tracker);
-        return tracker;
-    }
-
-    /**
      * Create a Snowplow tracker using Configuration objects.
      *
      * @param trackerConfig a TrackerConfiguration
@@ -107,6 +92,21 @@ public class Snowplow {
         Tracker tracker =  new Tracker(trackerConfig, emitter, subject);
         registerTracker(tracker);
         return tracker;
+    }
+
+    /**
+     * Create a Snowplow tracker with default configuration by providing three parameters.
+     *
+     * @param collectorUrl collector endpoint
+     * @param namespace unique identifier for the Tracker instance
+     * @param appId application ID
+     * @return the created Tracker
+     */
+    public static Tracker createTracker(String collectorUrl, String namespace, String appId) {
+        TrackerConfiguration trackerConfig = new TrackerConfiguration(namespace, appId);
+        NetworkConfiguration networkConfig = new NetworkConfiguration(collectorUrl);
+
+        return createTracker(trackerConfig, networkConfig, new EmitterConfiguration(), new SubjectConfiguration());
     }
 
     /**

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2014-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.tracker;
+
+import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Snowplow {
+
+    private static final Map<String, Tracker> trackers = new HashMap<>();
+    private static Tracker defaultTracker;
+
+    public static Map<String, Tracker> getTrackers() {
+        return trackers;
+    }
+
+    public static Tracker getDefaultTracker() {
+        return defaultTracker;
+    }
+
+    public static void setDefaultTracker(Tracker tracker) {
+        defaultTracker = tracker;
+    }
+
+    public static Tracker createTracker(String collectorUrl, String namespace, String appId) {
+        BatchEmitter emitter = BatchEmitter.builder().url(collectorUrl).build();
+        Tracker tracker = new Tracker.TrackerBuilder(emitter, namespace, appId).build();
+        registerTracker(tracker);
+        return tracker;
+    }
+
+    public static void registerTracker(Tracker tracker) {
+        String namespace = tracker.getNamespace();
+        if (trackers.containsKey(namespace)) {
+            throw new IllegalArgumentException("Tracker with this namespace already exists.");
+        }
+
+        trackers.put(namespace, tracker);
+
+        if (defaultTracker == null) {
+            defaultTracker = tracker;
+        }
+    }
+
+    public static Tracker getTracker(String namespace) {
+        return trackers.get(namespace);
+    }
+
+    public static boolean removeTracker(String namespace) {
+        Tracker removedTracker = trackers.remove(namespace);
+        if ((defaultTracker != null) && defaultTracker.getNamespace().equals(namespace)) {
+            defaultTracker = null;
+        }
+        return removedTracker != null;
+    }
+
+    public static boolean removeTracker(Tracker tracker) {
+        return removeTracker(tracker.getNamespace());
+    }
+
+    public static void reset() {
+        trackers.clear();
+        defaultTracker = null;
+    }
+}

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 // This library
+import com.snowplowanalytics.snowplow.tracker.configuration.SubjectConfiguration;
 import com.snowplowanalytics.snowplow.tracker.constants.Parameter;
 
 /**
@@ -28,23 +29,18 @@ public class Subject {
 
     private HashMap<String, String> standardPairs = new HashMap<>();
 
-    /**
-     * Creates a Subject which will add extra data to each event.
-     *
-     * @param builder The builder that constructs a subject
-     */
-    private Subject(SubjectBuilder builder) {
-        this.setUserId(builder.userId);
-        this.setScreenResolution(builder.screenResWidth, builder.screenResHeight);
-        this.setViewPort(builder.viewPortWidth, builder.viewPortHeight);
-        this.setColorDepth(builder.colorDepth);
-        this.setTimezone(builder.timezone);
-        this.setLanguage(builder.language);
-        this.setIpAddress(builder.ipAddress);
-        this.setUseragent(builder.useragent);
-        this.setNetworkUserId(builder.networkUserId);
-        this.setDomainUserId(builder.domainUserId);
-        this.setDomainSessionId(builder.domainSessionId);
+    public Subject(SubjectConfiguration subjectConfig) {
+        setUserId(subjectConfig.getUserId());
+        setScreenResolution(subjectConfig.getScreenResWidth(), subjectConfig.getScreenResHeight());
+        setViewPort(subjectConfig.getViewPortWidth(), subjectConfig.getViewPortHeight());
+        setColorDepth(subjectConfig.getColorDepth());
+        setTimezone(subjectConfig.getTimezone());
+        setLanguage(subjectConfig.getLanguage());
+        setIpAddress(subjectConfig.getIpAddress());
+        setUseragent(subjectConfig.getUseragent());
+        setNetworkUserId(subjectConfig.getNetworkUserId());
+        setDomainUserId(subjectConfig.getDomainUserId());
+        setDomainSessionId(subjectConfig.getDomainSessionId());
     }
 
     /**
@@ -189,7 +185,22 @@ public class Subject {
          * @return a new Subject object
          */
         public Subject build() {
-            return new Subject(this);
+            SubjectConfiguration subjectConfig = new SubjectConfiguration();
+
+
+//            setUserId(subjectConfig.getUserId());
+//            setScreenResolution(subjectConfig.getScreenResWidth(), subjectConfig.getScreenResHeight());
+//            setViewPort(subjectConfig.getViewPortWidth(), subjectConfig.getViewPortHeight());
+//            setColorDepth(subjectConfig.getColorDepth());
+//            setTimezone(subjectConfig.getTimezone());
+//            setLanguage(subjectConfig.getLanguage());
+//            setIpAddress(subjectConfig.getIpAddress());
+//            setUseragent(subjectConfig.getUseragent());
+//            setNetworkUserId(subjectConfig.getNetworkUserId());
+//            setDomainUserId(subjectConfig.getDomainUserId());
+//            setDomainSessionId(subjectConfig.getDomainSessionId());
+
+            return new Subject(subjectConfig);
         }
     }
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
@@ -185,20 +185,18 @@ public class Subject {
          * @return a new Subject object
          */
         public Subject build() {
-            SubjectConfiguration subjectConfig = new SubjectConfiguration();
-
-
-//            setUserId(subjectConfig.getUserId());
-//            setScreenResolution(subjectConfig.getScreenResWidth(), subjectConfig.getScreenResHeight());
-//            setViewPort(subjectConfig.getViewPortWidth(), subjectConfig.getViewPortHeight());
-//            setColorDepth(subjectConfig.getColorDepth());
-//            setTimezone(subjectConfig.getTimezone());
-//            setLanguage(subjectConfig.getLanguage());
-//            setIpAddress(subjectConfig.getIpAddress());
-//            setUseragent(subjectConfig.getUseragent());
-//            setNetworkUserId(subjectConfig.getNetworkUserId());
-//            setDomainUserId(subjectConfig.getDomainUserId());
-//            setDomainSessionId(subjectConfig.getDomainSessionId());
+            SubjectConfiguration subjectConfig = new SubjectConfiguration()
+                    .userId(userId)
+                    .screenResolution(screenResWidth, screenResHeight)
+                    .viewPort(viewPortWidth, viewPortHeight)
+                    .colorDepth(colorDepth)
+                    .timezone(timezone)
+                    .language(language)
+                    .ipAddress(ipAddress)
+                    .useragent(useragent)
+                    .networkUserId(networkUserId)
+                    .domainUserId(domainUserId)
+                    .domainSessionId(domainSessionId);
 
             return new Subject(subjectConfig);
         }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
@@ -29,6 +29,11 @@ public class Subject {
 
     private HashMap<String, String> standardPairs = new HashMap<>();
 
+    /**
+     * Creates a Subject instance from a SubjectConfiguration.
+     *
+     * @param subjectConfig a SubjectConfiguration
+     */
     public Subject(SubjectConfiguration subjectConfig) {
         setUserId(subjectConfig.getUserId());
         setScreenResolution(subjectConfig.getScreenResWidth(), subjectConfig.getScreenResHeight());

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -39,7 +39,7 @@ public class Tracker {
 
 
     public Tracker(TrackerConfiguration trackerConfig, Emitter emitter) {
-        this(trackerConfig, emitter, new Subject.SubjectBuilder().build());
+        this(trackerConfig, emitter, null);
     }
 
     public Tracker(TrackerConfiguration trackerConfig, Emitter emitter, Subject subject) {

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -35,13 +35,22 @@ public class Tracker {
     /**
      * Creates a new Snowplow Tracker.
      *
+     * @param trackerConfig a TrackerConfiguration object
+     * @param emitter an Emitter
+     *
      */
-
-
     public Tracker(TrackerConfiguration trackerConfig, Emitter emitter) {
         this(trackerConfig, emitter, null);
     }
 
+    /**
+     * Creates a new Snowplow Tracker.
+     *
+     * @param trackerConfig a TrackerConfiguration object
+     * @param emitter an Emitter
+     * @param subject a Subject
+     *
+     */
     public Tracker(TrackerConfiguration trackerConfig, Emitter emitter, Subject subject) {
 
         // Precondition checks
@@ -59,10 +68,6 @@ public class Tracker {
         this.emitter = emitter;
         this.subject = subject;
 
-    }
-
-    public static TrackerBuilder builder(Emitter emitter, String namespace, String appId) {
-        return new TrackerBuilder(emitter, namespace, appId);
     }
 
     /**
@@ -130,6 +135,10 @@ public class Tracker {
                     .base64Encoded(base64Encoded);
             return new Tracker(trackerConfig, emitter, subject);
         }
+    }
+
+    public static TrackerBuilder builder(Emitter emitter, String namespace, String appId) {
+        return new TrackerBuilder(emitter, namespace, appId);
     }
 
     // --- Setters

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -12,6 +12,7 @@
  */
 package com.snowplowanalytics.snowplow.tracker;
 
+import com.snowplowanalytics.snowplow.tracker.configuration.TrackerConfiguration;
 import com.snowplowanalytics.snowplow.tracker.constants.Constants;
 import com.snowplowanalytics.snowplow.tracker.constants.Parameter;
 import com.snowplowanalytics.snowplow.tracker.emitter.Emitter;
@@ -34,24 +35,29 @@ public class Tracker {
     /**
      * Creates a new Snowplow Tracker.
      *
-     * @param builder The builder that constructs a tracker
      */
-    private Tracker(TrackerBuilder builder) {
+
+
+    public Tracker(TrackerConfiguration trackerConfig, Emitter emitter) {
+        this(trackerConfig, emitter, new Subject.SubjectBuilder().build());
+    }
+
+    public Tracker(TrackerConfiguration trackerConfig, Emitter emitter, Subject subject) {
 
         // Precondition checks
-        Objects.requireNonNull(builder.emitter);
-        Objects.requireNonNull(builder.namespace);
-        Objects.requireNonNull(builder.appId);
-        if (builder.namespace.isEmpty()) {
+        Objects.requireNonNull(emitter);
+        Objects.requireNonNull(trackerConfig.getNamespace());
+        Objects.requireNonNull(trackerConfig.getAppId());
+        if (trackerConfig.getNamespace().isEmpty()) {
             throw new IllegalArgumentException("namespace cannot be empty");
         }
-        if (builder.appId.isEmpty()) {
+        if (trackerConfig.getAppId().isEmpty()) {
             throw new IllegalArgumentException("appId cannot be empty");
         }
 
-        this.parameters = new TrackerParameters(builder.appId, builder.platform, builder.namespace, Version.TRACKER, builder.base64Encoded);
-        this.emitter = builder.emitter;
-        this.subject = builder.subject;
+        this.parameters = new TrackerParameters(trackerConfig.getAppId(), trackerConfig.getPlatform(), trackerConfig.getNamespace(), Version.TRACKER, trackerConfig.isBase64Encoded());
+        this.emitter = emitter;
+        this.subject = subject;
 
     }
 
@@ -119,7 +125,10 @@ public class Tracker {
          * @return a new Tracker object
          */
         public Tracker build() {
-            return new Tracker(this);
+            TrackerConfiguration trackerConfig = new TrackerConfiguration(namespace, appId)
+                    .platform(platform)
+                    .base64Encoded(base64Encoded);
+            return new Tracker(trackerConfig, emitter, subject);
         }
     }
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/EmitterConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/EmitterConfiguration.java
@@ -100,36 +100,83 @@ public class EmitterConfiguration {
 
     // Builder methods
 
+    /**
+     * The default batch size is 50.
+     *
+     * @param batchSize The count of events to send in one HTTP request
+     * @return itself
+     */
     public EmitterConfiguration batchSize(int batchSize) {
         this.batchSize = batchSize;
         return this;
     }
 
+    /**
+     * The default buffer capacity is 10 000 events.
+     * When the buffer is full (due to network outage), new events are lost.
+     *
+     * @param bufferCapacity The maximum capacity of the default InMemoryEventStore event buffer
+     * @return itself
+     */
     public EmitterConfiguration bufferCapacity(int bufferCapacity) {
         this.bufferCapacity = bufferCapacity;
         return this;
     }
 
+    /**
+     * The default EventStore is InMemoryEventStore.
+     *
+     * @param eventStore The EventStore to use
+     * @return itself
+     */
     public EmitterConfiguration eventStore(EventStore eventStore) {
         this.eventStore = eventStore;
         return this;
     }
 
+    /**
+     * Set custom retry rules for HTTP status codes received in emit responses from the Collector.
+     * By default, retry will not occur for status codes 400, 401, 403, 410 or 422. This can be overridden here.
+     * Note that 2xx codes will never retry as they are considered successful.
+     * @param customRetryForStatusCodes Mapping of integers (status codes) to booleans (true for retry and false for not retry)
+     * @return itself
+     */
     public EmitterConfiguration customRetryForStatusCodes(Map<Integer, Boolean> customRetryForStatusCodes) {
         this.customRetryForStatusCodes = customRetryForStatusCodes;
         return this;
     }
 
+    /**
+     * Sets the Thread Count for the ScheduledExecutorService (default is 50).
+     *
+     * @param threadCount the size of the thread pool
+     * @return itself
+     */
     public EmitterConfiguration threadCount(int threadCount) {
         this.threadCount = threadCount;
         return this;
     }
 
+    /**
+     * Set a custom ScheduledExecutorService to send http requests (default is ScheduledThreadPoolExecutor).
+     * <p>
+     * <b>Implementation note: </b><em>Be aware that calling `close()` on a BatchEmitter instance
+     * has a side-effect and will shutdown that ExecutorService.</em>
+     *
+     * @param requestExecutorService the ScheduledExecutorService to use
+     * @return itself
+     */
     public EmitterConfiguration requestExecutorService(ScheduledExecutorService requestExecutorService) {
         this.requestExecutorService = requestExecutorService;
         return this;
     }
 
+    /**
+     * Provide a custom EmitterCallback to access successfully sent or failed event payloads.
+     *
+     * @param callback an EmitterCallback
+     * @return itself
+     */
     public EmitterConfiguration callback(EmitterCallback callback) {
         this.callback = callback;
         return this;

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/EmitterConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/EmitterConfiguration.java
@@ -12,9 +12,10 @@
  */
 package com.snowplowanalytics.snowplow.tracker.configuration;
 
+import com.snowplowanalytics.snowplow.tracker.emitter.EmitterCallback;
 import com.snowplowanalytics.snowplow.tracker.emitter.EventStore;
 
-import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 
 public class EmitterConfiguration {
@@ -22,9 +23,10 @@ public class EmitterConfiguration {
     private int batchSize; // Optional
     private int bufferCapacity; // Optional
     private EventStore eventStore;  // Optional
-    private List<Integer> fatalResponseCodes;  // Optional
+    private Map<Integer, Boolean> customRetryForStatusCodes;  // Optional
     private int threadCount; // Optional
     private ScheduledExecutorService requestExecutorService; // Optional
+    private EmitterCallback callback; // Optional
 
     // Getters and Setters
 
@@ -52,12 +54,12 @@ public class EmitterConfiguration {
         this.eventStore = eventStore;
     }
 
-    public List<Integer> getFatalResponseCodes() {
-        return fatalResponseCodes;
+    public Map<Integer, Boolean> getCustomRetryForStatusCodes() {
+        return customRetryForStatusCodes;
     }
 
-    public void setFatalResponseCodes(List<Integer> fatalResponseCodes) {
-        this.fatalResponseCodes = fatalResponseCodes;
+    public void setCustomRetryForStatusCodes(Map<Integer, Boolean> customRetryForStatusCodes) {
+        this.customRetryForStatusCodes = customRetryForStatusCodes;
     }
 
     public int getThreadCount() {
@@ -76,15 +78,24 @@ public class EmitterConfiguration {
         this.requestExecutorService = requestExecutorService;
     }
 
+    public EmitterCallback getCallback() {
+        return callback;
+    }
+
+    public void setCallback(EmitterCallback callback) {
+        this.callback = callback;
+    }
+
     // Constructor
 
     public EmitterConfiguration() {
         batchSize = 50;
-        bufferCapacity = Integer.MAX_VALUE;
+        bufferCapacity = 10000;
         eventStore = null;
-        fatalResponseCodes = null;
+        customRetryForStatusCodes = null;
         threadCount = 50;
         requestExecutorService = null;
+        callback = null;
     }
 
     // Builder methods
@@ -104,8 +115,8 @@ public class EmitterConfiguration {
         return this;
     }
 
-    public EmitterConfiguration fatalResponseCodes(List<Integer> fatalResponseCodes) {
-        this.fatalResponseCodes = fatalResponseCodes;
+    public EmitterConfiguration customRetryForStatusCodes(Map<Integer, Boolean> customRetryForStatusCodes) {
+        this.customRetryForStatusCodes = customRetryForStatusCodes;
         return this;
     }
 
@@ -116,6 +127,11 @@ public class EmitterConfiguration {
 
     public EmitterConfiguration requestExecutorService(ScheduledExecutorService requestExecutorService) {
         this.requestExecutorService = requestExecutorService;
+        return this;
+    }
+
+    public EmitterConfiguration callback(EmitterCallback callback) {
+        this.callback = callback;
         return this;
     }
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/EmitterConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/EmitterConfiguration.java
@@ -34,56 +34,28 @@ public class EmitterConfiguration {
         return batchSize;
     }
 
-    public void setBatchSize(int batchSize) {
-        this.batchSize = batchSize;
-    }
-
     public int getBufferCapacity() {
         return bufferCapacity;
-    }
-
-    public void setBufferCapacity(int bufferCapacity) {
-        this.bufferCapacity = bufferCapacity;
     }
 
     public EventStore getEventStore() {
         return eventStore;
     }
 
-    public void setEventStore(EventStore eventStore) {
-        this.eventStore = eventStore;
-    }
-
     public Map<Integer, Boolean> getCustomRetryForStatusCodes() {
         return customRetryForStatusCodes;
-    }
-
-    public void setCustomRetryForStatusCodes(Map<Integer, Boolean> customRetryForStatusCodes) {
-        this.customRetryForStatusCodes = customRetryForStatusCodes;
     }
 
     public int getThreadCount() {
         return threadCount;
     }
 
-    public void setThreadCount(int threadCount) {
-        this.threadCount = threadCount;
-    }
-
     public ScheduledExecutorService getRequestExecutorService() {
         return requestExecutorService;
     }
 
-    public void setRequestExecutorService(ScheduledExecutorService requestExecutorService) {
-        this.requestExecutorService = requestExecutorService;
-    }
-
     public EmitterCallback getCallback() {
         return callback;
-    }
-
-    public void setCallback(EmitterCallback callback) {
-        this.callback = callback;
     }
 
     // Constructor

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/EmitterConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/EmitterConfiguration.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2014-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.tracker.configuration;
+
+import com.snowplowanalytics.snowplow.tracker.emitter.EventStore;
+
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class EmitterConfiguration {
+
+    private int batchSize; // Optional
+    private int bufferCapacity; // Optional
+    private EventStore eventStore;  // Optional
+    private List<Integer> fatalResponseCodes;  // Optional
+    private int threadCount; // Optional
+    private ScheduledExecutorService requestExecutorService; // Optional
+
+    // Getters and Setters
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    public int getBufferCapacity() {
+        return bufferCapacity;
+    }
+
+    public void setBufferCapacity(int bufferCapacity) {
+        this.bufferCapacity = bufferCapacity;
+    }
+
+    public EventStore getEventStore() {
+        return eventStore;
+    }
+
+    public void setEventStore(EventStore eventStore) {
+        this.eventStore = eventStore;
+    }
+
+    public List<Integer> getFatalResponseCodes() {
+        return fatalResponseCodes;
+    }
+
+    public void setFatalResponseCodes(List<Integer> fatalResponseCodes) {
+        this.fatalResponseCodes = fatalResponseCodes;
+    }
+
+    public int getThreadCount() {
+        return threadCount;
+    }
+
+    public void setThreadCount(int threadCount) {
+        this.threadCount = threadCount;
+    }
+
+    public ScheduledExecutorService getRequestExecutorService() {
+        return requestExecutorService;
+    }
+
+    public void setRequestExecutorService(ScheduledExecutorService requestExecutorService) {
+        this.requestExecutorService = requestExecutorService;
+    }
+
+    // Constructor
+
+    public EmitterConfiguration() {
+        batchSize = 50;
+        bufferCapacity = Integer.MAX_VALUE;
+        eventStore = null;
+        fatalResponseCodes = null;
+        threadCount = 50;
+        requestExecutorService = null;
+    }
+
+    // Builder methods
+
+    public EmitterConfiguration batchSize(int batchSize) {
+        this.batchSize = batchSize;
+        return this;
+    }
+
+    public EmitterConfiguration bufferCapacity(int bufferCapacity) {
+        this.bufferCapacity = bufferCapacity;
+        return this;
+    }
+
+    public EmitterConfiguration eventStore(EventStore eventStore) {
+        this.eventStore = eventStore;
+        return this;
+    }
+
+    public EmitterConfiguration fatalResponseCodes(List<Integer> fatalResponseCodes) {
+        this.fatalResponseCodes = fatalResponseCodes;
+        return this;
+    }
+
+    public EmitterConfiguration threadCount(int threadCount) {
+        this.threadCount = threadCount;
+        return this;
+    }
+
+    public EmitterConfiguration requestExecutorService(ScheduledExecutorService requestExecutorService) {
+        this.requestExecutorService = requestExecutorService;
+        return this;
+    }
+}

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/EmitterConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/EmitterConfiguration.java
@@ -88,6 +88,14 @@ public class EmitterConfiguration {
 
     // Constructor
 
+    /**
+     * Create an EmitterConfiguration instance. The default configuration is:
+     * 50 batched events per request;
+     * maximum 10 000 events buffered in memory;
+     * 50 threads;
+     * no retry for request status codes 400, 401, 403, 410 or 422;
+     * and OkHttp (OkHttpClientAdapter) used for HTTP requests.
+     */
     public EmitterConfiguration() {
         batchSize = 50;
         bufferCapacity = 10000;

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/EmitterConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/EmitterConfiguration.java
@@ -30,30 +30,60 @@ public class EmitterConfiguration {
 
     // Getters and Setters
 
+    /**
+     * Returns the number of events to send per request (batched).
+     * @return the batch size
+     */
     public int getBatchSize() {
         return batchSize;
     }
 
+    /**
+     * Returns the maximum number of events to buffer in memory.
+     * @return maximum buffer capacity
+     */
     public int getBufferCapacity() {
         return bufferCapacity;
     }
 
+    /**
+     * Returns the EventStore used to buffer events.
+     * @return EventStore instance
+     */
     public EventStore getEventStore() {
         return eventStore;
     }
 
+    /**
+     * Returns the custom configuration for HTTP status codes. "True" means the
+     * @return map of integers (status codes) to booleans (true for retry and false for not retry)
+     */
     public Map<Integer, Boolean> getCustomRetryForStatusCodes() {
         return customRetryForStatusCodes;
     }
 
+    /**
+     * Returns the number of threads used for event sending using the ScheduledExecutorService.
+     * @return thread count
+     */
     public int getThreadCount() {
         return threadCount;
     }
 
+    /**
+     * Returns the ScheduledExecutorService used for sending events.
+     * @return ScheduledExecutorService object
+     */
     public ScheduledExecutorService getRequestExecutorService() {
         return requestExecutorService;
     }
 
+    /**
+     * Returns the custom callback which is called when events are successfully sent to the collector,
+     * or after certain failure conditions.
+     *
+     * @return EmitterCallback object
+     */
     public EmitterCallback getCallback() {
         return callback;
     }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/NetworkConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/NetworkConfiguration.java
@@ -58,16 +58,36 @@ public class NetworkConfiguration {
 
     // Builder methods
 
+    /**
+     * Sets a custom HttpClientAdapter (default is OkHttpClientAdapter).
+     *
+     * @param httpClientAdapter the adapter to use
+     * @return itself
+     */
     public NetworkConfiguration httpClientAdapter(HttpClientAdapter httpClientAdapter) {
         this.httpClientAdapter = httpClientAdapter;
         return this;
     }
 
+    /**
+     * Sets the endpoint url for when a httpClientAdapter is not specified.
+     * It will be used to create the default OkHttpClientAdapter.
+     *
+     * @param collectorUrl the url for the default httpClientAdapter
+     * @return itself
+     */
     public NetworkConfiguration collectorUrl(String collectorUrl) {
         this.collectorUrl = collectorUrl;
         return this;
     }
 
+    /**
+     * Adds a custom CookieJar to be used with OkHttpClientAdapters.
+     * Will be ignored if a custom httpClientAdapter is provided.
+     *
+     * @param cookieJar the CookieJar to use
+     * @return itself
+     */
     public NetworkConfiguration cookieJar(CookieJar cookieJar) {
         this.cookieJar = cookieJar;
         return this;

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/NetworkConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/NetworkConfiguration.java
@@ -24,14 +24,26 @@ public class NetworkConfiguration {
 
     // Getters and Setters
 
+    /**
+     * Returns the HttpClientAdapter used.
+     * @return HttpClientAdapter object
+     */
     public HttpClientAdapter getHttpClientAdapter() {
         return httpClientAdapter;
     }
 
+    /**
+     * Returns the event collector URL endpoint.
+     * @return collector URL
+     */
     public String getCollectorUrl() {
         return collectorUrl;
     }
 
+    /**
+     * Returns the OkHttp CookieJar used for persisting cookies.
+     * @return CookieJar object
+     */
     public CookieJar getCookieJar() {
         return cookieJar;
     }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/NetworkConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/NetworkConfiguration.java
@@ -28,24 +28,12 @@ public class NetworkConfiguration {
         return httpClientAdapter;
     }
 
-    public void setHttpClientAdapter(HttpClientAdapter httpClientAdapter) {
-        this.httpClientAdapter = httpClientAdapter;
-    }
-
     public String getCollectorUrl() {
         return collectorUrl;
     }
 
-    public void setCollectorUrl(String collectorUrl) {
-        this.collectorUrl = collectorUrl;
-    }
-
     public CookieJar getCookieJar() {
         return cookieJar;
-    }
-
-    public void setCookieJar(CookieJar cookieJar) {
-        this.cookieJar = cookieJar;
     }
 
     // Constructor

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/NetworkConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/NetworkConfiguration.java
@@ -50,9 +50,37 @@ public class NetworkConfiguration {
 
     // Constructor
 
+    /**
+     * Create a NetworkConfiguration instance. No arguments are required for this constructor, but you will need to
+     * provide either a collector URL or an HttpClientAdapter object before using this NetworkConfiguration.
+     */
     public NetworkConfiguration() {
         httpClientAdapter = null;
         collectorUrl = null;
+        cookieJar = null;
+    }
+
+    /**
+     * Create a NetworkConfiguration instance and specify a custom HttpClientAdapter to use
+     * (the default is OkHttpClientAdapter).
+     *
+     * @param httpClientAdapter the adapter to use
+     */
+    public NetworkConfiguration(HttpClientAdapter httpClientAdapter) {
+        this.httpClientAdapter = httpClientAdapter;
+        collectorUrl = null;
+        cookieJar = null;
+    }
+
+    /**
+     * Create a NetworkConfiguration instance with a collector endpoint URL. The URL will be used
+     * to create the default OkHttpClientAdapter.
+     *
+     * @param collectorUrl the url for the default httpClientAdapter
+     */
+    public NetworkConfiguration(String collectorUrl) {
+        httpClientAdapter = null;
+        this.collectorUrl = collectorUrl;
         cookieJar = null;
     }
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/NetworkConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/NetworkConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2014-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.tracker.configuration;
+
+import com.snowplowanalytics.snowplow.tracker.http.HttpClientAdapter;
+import okhttp3.CookieJar;
+
+
+public class NetworkConfiguration {
+
+    private HttpClientAdapter httpClientAdapter; // Optional
+    private String collectorUrl; // Required if not specifying a httpClientAdapter
+    private CookieJar cookieJar; // Optional
+
+    // Getters and Setters
+
+    public HttpClientAdapter getHttpClientAdapter() {
+        return httpClientAdapter;
+    }
+
+    public void setHttpClientAdapter(HttpClientAdapter httpClientAdapter) {
+        this.httpClientAdapter = httpClientAdapter;
+    }
+
+    public String getCollectorUrl() {
+        return collectorUrl;
+    }
+
+    public void setCollectorUrl(String collectorUrl) {
+        this.collectorUrl = collectorUrl;
+    }
+
+    public CookieJar getCookieJar() {
+        return cookieJar;
+    }
+
+    public void setCookieJar(CookieJar cookieJar) {
+        this.cookieJar = cookieJar;
+    }
+
+    // Constructor
+
+    public NetworkConfiguration() {
+        httpClientAdapter = null;
+        collectorUrl = null;
+        cookieJar = null;
+    }
+
+    // Builder methods
+
+    public NetworkConfiguration httpClientAdapter(HttpClientAdapter httpClientAdapter) {
+        this.httpClientAdapter = httpClientAdapter;
+        return this;
+    }
+
+    public NetworkConfiguration collectorUrl(String collectorUrl) {
+        this.collectorUrl = collectorUrl;
+        return this;
+    }
+
+    public NetworkConfiguration cookieJar(CookieJar cookieJar) {
+        this.cookieJar = cookieJar;
+        return this;
+    }
+}

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/NetworkConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/NetworkConfiguration.java
@@ -18,9 +18,9 @@ import okhttp3.CookieJar;
 
 public class NetworkConfiguration {
 
-    private HttpClientAdapter httpClientAdapter; // Optional
-    private String collectorUrl; // Required if not specifying a httpClientAdapter
-    private CookieJar cookieJar; // Optional
+    private HttpClientAdapter httpClientAdapter = null; // Optional
+    private String collectorUrl = null; // Required if not specifying a httpClientAdapter
+    private CookieJar cookieJar = null; // Optional
 
     // Getters and Setters
 
@@ -48,17 +48,7 @@ public class NetworkConfiguration {
         return cookieJar;
     }
 
-    // Constructor
-
-    /**
-     * Create a NetworkConfiguration instance. No arguments are required for this constructor, but you will need to
-     * provide either a collector URL or an HttpClientAdapter object before using this NetworkConfiguration.
-     */
-    public NetworkConfiguration() {
-        httpClientAdapter = null;
-        collectorUrl = null;
-        cookieJar = null;
-    }
+    // Constructors
 
     /**
      * Create a NetworkConfiguration instance and specify a custom HttpClientAdapter to use
@@ -68,8 +58,6 @@ public class NetworkConfiguration {
      */
     public NetworkConfiguration(HttpClientAdapter httpClientAdapter) {
         this.httpClientAdapter = httpClientAdapter;
-        collectorUrl = null;
-        cookieJar = null;
     }
 
     /**
@@ -79,9 +67,7 @@ public class NetworkConfiguration {
      * @param collectorUrl the url for the default httpClientAdapter
      */
     public NetworkConfiguration(String collectorUrl) {
-        httpClientAdapter = null;
         this.collectorUrl = collectorUrl;
-        cookieJar = null;
     }
 
     // Builder methods

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/SubjectConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/SubjectConfiguration.java
@@ -139,6 +139,9 @@ public class SubjectConfiguration {
 
     // Constructor
 
+    /**
+     * Create a Subject instance. By default, timezone is set to the server's timezone.
+     */
     public SubjectConfiguration() {
         userId = null; // Optional
         screenResWidth = 0; // Optional

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/SubjectConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/SubjectConfiguration.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2014-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.tracker.configuration;
+
+import com.snowplowanalytics.snowplow.tracker.Utils;
+
+public class SubjectConfiguration {
+
+    private String userId; // Optional
+    private int screenResWidth; // Optional
+    private int screenResHeight; // Optional
+    private int viewPortWidth; // Optional
+    private int viewPortHeight; // Optional
+    private int colorDepth; // Optional
+    private String timezone; // Optional
+    private String language; // Optional
+    private String ipAddress; // Optional
+    private String useragent; // Optional
+    private String networkUserId; // Optional
+    private String domainUserId; // Optional
+    private String domainSessionId; // Optional
+
+    // Getters and Setters
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public int getScreenResWidth() {
+        return screenResWidth;
+    }
+
+    public void setScreenResWidth(int screenResWidth) {
+        this.screenResWidth = screenResWidth;
+    }
+
+    public int getScreenResHeight() {
+        return screenResHeight;
+    }
+
+    public void setScreenResHeight(int screenResHeight) {
+        this.screenResHeight = screenResHeight;
+    }
+
+    public int getViewPortWidth() {
+        return viewPortWidth;
+    }
+
+    public void setViewPortWidth(int viewPortWidth) {
+        this.viewPortWidth = viewPortWidth;
+    }
+
+    public int getViewPortHeight() {
+        return viewPortHeight;
+    }
+
+    public void setViewPortHeight(int viewPortHeight) {
+        this.viewPortHeight = viewPortHeight;
+    }
+
+    public int getColorDepth() {
+        return colorDepth;
+    }
+
+    public void setColorDepth(int colorDepth) {
+        this.colorDepth = colorDepth;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public void setTimezone(String timezone) {
+        this.timezone = timezone;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public String getUseragent() {
+        return useragent;
+    }
+
+    public void setUseragent(String useragent) {
+        this.useragent = useragent;
+    }
+
+    public String getNetworkUserId() {
+        return networkUserId;
+    }
+
+    public void setNetworkUserId(String networkUserId) {
+        this.networkUserId = networkUserId;
+    }
+
+    public String getDomainUserId() {
+        return domainUserId;
+    }
+
+    public void setDomainUserId(String domainUserId) {
+        this.domainUserId = domainUserId;
+    }
+
+    public String getDomainSessionId() {
+        return domainSessionId;
+    }
+
+    public void setDomainSessionId(String domainSessionId) {
+        this.domainSessionId = domainSessionId;
+    }
+
+
+    // Constructor
+
+    public SubjectConfiguration() {
+        userId = null; // Optional
+        screenResWidth = 0; // Optional
+        screenResHeight = 0; // Optional
+        viewPortWidth = 0; // Optional
+        viewPortHeight = 0; // Optional
+        colorDepth = 0; // Optional
+        timezone = Utils.getTimezone(); // Optional
+        language = null; // Optional
+        ipAddress = null; // Optional
+        useragent = null; // Optional
+        networkUserId = null; // Optional
+        domainUserId = null; // Optional
+        domainSessionId = null; // Optional
+    }
+
+    // Builder methods
+
+
+
+
+}

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/SubjectConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/SubjectConfiguration.java
@@ -36,106 +36,53 @@ public class SubjectConfiguration {
         return userId;
     }
 
-    public void setUserId(String userId) {
-        this.userId = userId;
-    }
-
     public int getScreenResWidth() {
         return screenResWidth;
-    }
-
-    public void setScreenResWidth(int screenResWidth) {
-        this.screenResWidth = screenResWidth;
     }
 
     public int getScreenResHeight() {
         return screenResHeight;
     }
 
-    public void setScreenResHeight(int screenResHeight) {
-        this.screenResHeight = screenResHeight;
-    }
-
     public int getViewPortWidth() {
         return viewPortWidth;
-    }
-
-    public void setViewPortWidth(int viewPortWidth) {
-        this.viewPortWidth = viewPortWidth;
     }
 
     public int getViewPortHeight() {
         return viewPortHeight;
     }
 
-    public void setViewPortHeight(int viewPortHeight) {
-        this.viewPortHeight = viewPortHeight;
-    }
-
     public int getColorDepth() {
         return colorDepth;
-    }
-
-    public void setColorDepth(int colorDepth) {
-        this.colorDepth = colorDepth;
     }
 
     public String getTimezone() {
         return timezone;
     }
 
-    public void setTimezone(String timezone) {
-        this.timezone = timezone;
-    }
-
     public String getLanguage() {
         return language;
-    }
-
-    public void setLanguage(String language) {
-        this.language = language;
     }
 
     public String getIpAddress() {
         return ipAddress;
     }
 
-    public void setIpAddress(String ipAddress) {
-        this.ipAddress = ipAddress;
-    }
-
     public String getUseragent() {
         return useragent;
-    }
-
-    public void setUseragent(String useragent) {
-        this.useragent = useragent;
     }
 
     public String getNetworkUserId() {
         return networkUserId;
     }
 
-    public void setNetworkUserId(String networkUserId) {
-        this.networkUserId = networkUserId;
-    }
-
     public String getDomainUserId() {
         return domainUserId;
-    }
-
-    public void setDomainUserId(String domainUserId) {
-        this.domainUserId = domainUserId;
     }
 
     public String getDomainSessionId() {
         return domainSessionId;
     }
-
-    public void setDomainSessionId(String domainSessionId) {
-        this.domainSessionId = domainSessionId;
-    }
-
 
     // Constructor
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/SubjectConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/SubjectConfiguration.java
@@ -157,7 +157,94 @@ public class SubjectConfiguration {
 
     // Builder methods
 
+    public SubjectConfiguration userId(String userId) {
+        this.userId = userId;
+        return this;
+    }
 
+    public SubjectConfiguration screenResolution(int width, int height) {
+        screenResWidth = width;
+        screenResHeight = height;
+        return this;
+    }
 
+    public SubjectConfiguration viewPort(int width, int height) {
+        viewPortWidth = width;
+        viewPortHeight = height;
+        return this;
+    }
 
+    /**
+     * @param depth a color depth integer
+     * @return itself
+     */
+    public SubjectConfiguration colorDepth(int depth) {
+        colorDepth = depth;
+        return this;
+    }
+
+    /**
+     * Note that timezone is set by default to the server's timezone
+     * (`TimeZone tz = Calendar.getInstance().getTimeZone().getID()`)
+     * @param timezone a timezone string
+     * @return itself
+     */
+    public SubjectConfiguration timezone(String timezone) {
+        this.timezone = timezone;
+        return this;
+    }
+
+    /**
+     * @param language a language string
+     * @return itself
+     */
+    public SubjectConfiguration language(String language) {
+        this.language = language;
+        return this;
+    }
+
+    /**
+     * @param ipAddress a ipAddress string
+     * @return itself
+     */
+    public SubjectConfiguration ipAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+        return this;
+    }
+
+    /**
+     * @param useragent a useragent string
+     * @return itself
+     */
+    public SubjectConfiguration useragent(String useragent) {
+        this.useragent = useragent;
+        return this;
+    }
+
+    /**
+     * @param networkUserId a networkUserId string
+     * @return itself
+     */
+    public SubjectConfiguration networkUserId(String networkUserId) {
+        this.networkUserId = networkUserId;
+        return this;
+    }
+
+    /**
+     * @param domainUserId a domainUserId string
+     * @return itself
+     */
+    public SubjectConfiguration domainUserId(String domainUserId) {
+        this.domainUserId = domainUserId;
+        return this;
+    }
+
+    /**
+     * @param domainSessionId a domainSessionId string
+     * @return itself
+     */
+    public SubjectConfiguration domainSessionId(String domainSessionId) {
+        this.domainSessionId = domainSessionId;
+        return this;
+    }
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/SubjectConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/SubjectConfiguration.java
@@ -32,54 +32,106 @@ public class SubjectConfiguration {
 
     // Getters and Setters
 
+    /**
+     * Returns the user ID.
+     * @return user ID
+     */
     public String getUserId() {
         return userId;
     }
 
+    /**
+     * Returns the screen resolution width, in pixels.
+     * @return screen width
+     */
     public int getScreenResWidth() {
         return screenResWidth;
     }
 
+    /**
+     * Returns the screen resolution height, in pixels.
+     * @return screen height
+     */
     public int getScreenResHeight() {
         return screenResHeight;
     }
 
+    /**
+     * Returns the viewport width, in pixels.
+     * @return viewport width
+     */
     public int getViewPortWidth() {
         return viewPortWidth;
     }
 
+    /**
+     * Returns the viewport height, in pixels.
+     * @return viewport height
+     */
     public int getViewPortHeight() {
         return viewPortHeight;
     }
 
+    /**
+     * Returns the color depth.
+     * @return color depth
+     */
     public int getColorDepth() {
         return colorDepth;
     }
 
+    /**
+     * Returns the timezone. Automatically set by default to that of the server.
+     * @return timezone
+     */
     public String getTimezone() {
         return timezone;
     }
 
+    /**
+     * Returns the device language.
+     * @return language
+     */
     public String getLanguage() {
         return language;
     }
 
+    /**
+     * Returns the IP address.
+     * @return IP address
+     */
     public String getIpAddress() {
         return ipAddress;
     }
 
+    /**
+     * Returns the useragent.
+     * @return useragent
+     */
     public String getUseragent() {
         return useragent;
     }
 
+    /**
+     * Returns the network user ID (UUID string).
+     * @return network user ID
+     */
     public String getNetworkUserId() {
         return networkUserId;
     }
 
+    /**
+     * Returns the domain user ID (UUID string).
+     * @return domain user ID
+     */
     public String getDomainUserId() {
         return domainUserId;
     }
 
+    /**
+     * Returns the domain session ID (UUID string).
+     * @return domain session ID
+     */
     public String getDomainSessionId() {
         return domainSessionId;
     }
@@ -107,17 +159,34 @@ public class SubjectConfiguration {
 
     // Builder methods
 
+    /**
+     * Set a unique user ID.
+     * @param userId a user ID
+     * @return itself
+     */
     public SubjectConfiguration userId(String userId) {
         this.userId = userId;
         return this;
     }
 
+    /**
+     * Set the screen resolution.
+     * @param width width in pixels
+     * @param height height in pixels
+     * @return itself
+     */
     public SubjectConfiguration screenResolution(int width, int height) {
         screenResWidth = width;
         screenResHeight = height;
         return this;
     }
 
+    /**
+     * Set the viewport size.
+     * @param width width in pixels
+     * @param height height in pixels
+     * @return itself
+     */
     public SubjectConfiguration viewPort(int width, int height) {
         viewPortWidth = width;
         viewPortHeight = height;
@@ -172,6 +241,7 @@ public class SubjectConfiguration {
     }
 
     /**
+     * This overrides the network user ID set by the Collector in response Cookies.
      * @param networkUserId a networkUserId string
      * @return itself
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/TrackerConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/TrackerConfiguration.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2014-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.tracker.configuration;
+
+import com.snowplowanalytics.snowplow.tracker.DevicePlatform;
+
+
+public class TrackerConfiguration {
+    private final String namespace; // Required
+    private final String appId; // Required
+    private DevicePlatform platform; // Optional
+    private boolean base64Encoded; // Optional
+
+    // Getters and Setters
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public String getAppId() {
+        return appId;
+    }
+
+    public DevicePlatform getPlatform() {
+        return platform;
+    }
+
+    public void setPlatform(DevicePlatform platform) {
+        this.platform = platform;
+    }
+
+    public boolean isBase64Encoded() {
+        return base64Encoded;
+    }
+
+    public void setBase64Encoded(boolean base64Encoded) {
+        this.base64Encoded = base64Encoded;
+    }
+
+    // Constructor
+
+    public TrackerConfiguration(String namespace, String appId) {
+        this.namespace = namespace;
+        this.appId = appId;
+        this.platform = DevicePlatform.ServerSideApp;
+        this.base64Encoded = true;
+    }
+
+    // Builder methods
+
+    public TrackerConfiguration platform(DevicePlatform platform) {
+        this.platform = platform;
+        return this;
+    }
+
+    public TrackerConfiguration base64Encoded(boolean base64Encoded) {
+        this.base64Encoded = base64Encoded;
+        return this;
+    }
+}

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/TrackerConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/TrackerConfiguration.java
@@ -58,11 +58,23 @@ public class TrackerConfiguration {
 
     // Builder methods
 
+    /**
+     * The {@link DevicePlatform} the tracker is running on (default is "srv", ServerSideApp).
+     *
+     * @param platform The device platform the tracker is running on
+     * @return itself
+     */
     public TrackerConfiguration platform(DevicePlatform platform) {
         this.platform = platform;
         return this;
     }
 
+    /**
+     * Whether JSONs in the payload should be base-64 encoded (default is true)
+     *
+     * @param base64Encoded JSONs should be encoded or not
+     * @return itself
+     */
     public TrackerConfiguration base64Encoded(boolean base64Encoded) {
         this.base64Encoded = base64Encoded;
         return this;

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/TrackerConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/TrackerConfiguration.java
@@ -49,6 +49,13 @@ public class TrackerConfiguration {
 
     // Constructor
 
+    /**
+     * Create a TrackerConfiguration instance. The namespace is the unique identifier for the instance.
+     * By default, the platform is ServerSideApp, and JSONs will be base64 encoded.
+     *
+     * @param namespace identifier for the Tracker instance
+     * @param appId application ID
+     */
     public TrackerConfiguration(String namespace, String appId) {
         this.namespace = namespace;
         this.appId = appId;

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/TrackerConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/TrackerConfiguration.java
@@ -23,18 +23,34 @@ public class TrackerConfiguration {
 
     // Getters and Setters
 
+    /**
+     * Returns the unique tracker namespace.
+     * @return tracker namespace
+     */
     public String getNamespace() {
         return namespace;
     }
 
+    /**
+     * Returns the application ID.
+     * @return application ID
+     */
     public String getAppId() {
         return appId;
     }
 
+    /**
+     * Returns the DevicePlatform for the tracker.
+     * @return what platform the app is running on
+     */
     public DevicePlatform getPlatform() {
         return platform;
     }
 
+    /**
+     * Returns whether JSONs in the payload are base-64 encoded.
+     * @return true if encoded
+     */
     public boolean isBase64Encoded() {
         return base64Encoded;
     }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/TrackerConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/TrackerConfiguration.java
@@ -35,16 +35,8 @@ public class TrackerConfiguration {
         return platform;
     }
 
-    public void setPlatform(DevicePlatform platform) {
-        this.platform = platform;
-    }
-
     public boolean isBase64Encoded() {
         return base64Encoded;
-    }
-
-    public void setBase64Encoded(boolean base64Encoded) {
-        this.base64Encoded = base64Encoded;
     }
 
     // Constructor

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -206,7 +206,8 @@ public class BatchEmitter implements Emitter, Closeable {
                     .eventStore(eventStore)
                     .customRetryForStatusCodes(customRetryForStatusCodes)
                     .threadCount(threadCount)
-                    .requestExecutorService(requestExecutorService);
+                    .requestExecutorService(requestExecutorService)
+                    .callback(callback);
 
             return new BatchEmitter(networkConfig, emitterConfig);
         }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -224,6 +224,12 @@ public class BatchEmitter implements Emitter, Closeable {
         return new Builder2();
     }
 
+    /**
+     * Creates a BatchEmitter object from configuration objects.
+     *
+     * @param networkConfig a NetworkConfiguration object
+     * @param emitterConfig an EmitterConfiguration object
+     */
     public BatchEmitter(NetworkConfiguration networkConfig, EmitterConfiguration emitterConfig) {
         OkHttpClient client;
 
@@ -290,6 +296,11 @@ public class BatchEmitter implements Emitter, Closeable {
         }
     }
 
+    /**
+     * Creates a BatchEmitter instance using a NetworkConfiguration.
+     *
+     * @param networkConfig a NetworkConfiguration object
+     */
     public BatchEmitter(NetworkConfiguration networkConfig) {
         this(networkConfig, new EmitterConfiguration());
     }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -204,7 +204,7 @@ public class BatchEmitter implements Emitter, Closeable {
                     .batchSize(batchSize)
                     .bufferCapacity(bufferCapacity)
                     .eventStore(eventStore)
-                    .fatalResponseCodes(fatalResponseCodes)
+                    .customRetryForStatusCodes(customRetryForStatusCodes)
                     .threadCount(threadCount)
                     .requestExecutorService(requestExecutorService);
 
@@ -259,8 +259,8 @@ public class BatchEmitter implements Emitter, Closeable {
         retryDelay = new AtomicInteger(0);
         batchSize = emitterConfig.getBatchSize();
 
-        if (builder.callback != null) {
-            callback = builder.callback;
+        if (emitterConfig.getCallback() != null) {
+            callback = emitterConfig.getCallback();
         } else {
             callback = new EmitterCallback() {
                 @Override

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -20,6 +20,8 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.snowplowanalytics.snowplow.tracker.configuration.EmitterConfiguration;
+import com.snowplowanalytics.snowplow.tracker.configuration.NetworkConfiguration;
 import com.snowplowanalytics.snowplow.tracker.constants.Constants;
 import com.snowplowanalytics.snowplow.tracker.constants.Parameter;
 import com.snowplowanalytics.snowplow.tracker.http.HttpClientAdapter;
@@ -272,7 +274,61 @@ public class BatchEmitter implements Emitter, Closeable {
         } else {
             executor = Executors.newScheduledThreadPool(builder.threadCount, new EmitterThreadFactory());
         }
+    }
 
+    public BatchEmitter(EmitterConfiguration emitterConfig, NetworkConfiguration networkConfig) {
+        OkHttpClient client;
+
+        // Precondition checks
+        if (emitterConfig.getThreadCount() <= 0) {
+            throw new IllegalArgumentException("threadCount must be greater than 0");
+        }
+        if (emitterConfig.getBatchSize() <= 0) {
+            throw new IllegalArgumentException("batchSize must be greater than 0");
+        }
+        if (emitterConfig.getBufferCapacity() <= 0) {
+            throw new IllegalArgumentException("bufferCapacity must be greater than 0");
+        }
+
+        if (networkConfig.getHttpClientAdapter() != null) {
+            httpClientAdapter = networkConfig.getHttpClientAdapter();
+        } else {
+            Objects.requireNonNull(networkConfig.getCollectorUrl(), "Collector url must be specified if not using a httpClientAdapter");
+
+            if (networkConfig.getCookieJar() != null) {
+                client = new OkHttpClient.Builder()
+                        .cookieJar(networkConfig.getCookieJar())
+                        .build();
+            } else {
+                client = new OkHttpClient.Builder().build();
+            }
+
+            httpClientAdapter = OkHttpClientAdapter.builder() // use okhttp as a default
+                    .url(networkConfig.getCollectorUrl())
+                    .httpClient(client)
+                    .build();
+        }
+
+        retryDelay = new AtomicInteger(0);
+        batchSize = emitterConfig.getBatchSize();
+
+        if (emitterConfig.getEventStore() != null) {
+            eventStore = emitterConfig.getEventStore();
+        } else {
+            eventStore = new InMemoryEventStore(emitterConfig.getBufferCapacity());
+        }
+
+        if (emitterConfig.getFatalResponseCodes() != null) {
+            customRetryForStatusCodes = emitterConfig.getFatalResponseCodes();
+        } else {
+            customRetryForStatusCodes = new HashMap<>();
+        }
+
+        if (emitterConfig.getRequestExecutorService() != null) {
+            executor = emitterConfig.getRequestExecutorService();
+        } else {
+            executor = Executors.newScheduledThreadPool(emitterConfig.getThreadCount(), new EmitterThreadFactory());
+        }
     }
 
     /**
@@ -405,7 +461,6 @@ public class BatchEmitter implements Emitter, Closeable {
                     retryDelay.set(0);
                     eventStore.cleanupAfterSendingAttempt(false, batchedEvents.getBatchId());
                     callback.onSuccess(eventsInRequest);
-
 
                 } else if (!shouldRetry(code)) {
                     LOGGER.debug("BatchEmitter failed to send {} events. No retry for code {}: events dropped", eventsInRequest.size(), code);

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -195,8 +195,7 @@ public class BatchEmitter implements Emitter, Closeable {
         }
 
         public BatchEmitter build() {
-            NetworkConfiguration networkConfig = new NetworkConfiguration()
-                    .collectorUrl(collectorUrl)
+            NetworkConfiguration networkConfig = new NetworkConfiguration(collectorUrl)
                     .httpClientAdapter(httpClientAdapter)
                     .cookieJar(cookieJar);
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
@@ -18,11 +18,6 @@ import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
 import org.junit.After;
 import org.junit.Test;
 
-import java.sql.Array;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
 import static org.junit.Assert.*;
 
 public class SnowplowTest {

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
@@ -18,6 +18,11 @@ import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
 import org.junit.After;
 import org.junit.Test;
 
+import java.sql.Array;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
 import static org.junit.Assert.*;
 
 public class SnowplowTest {
@@ -29,12 +34,12 @@ public class SnowplowTest {
 
     @Test
     public void createsAndRetrievesATracker() {
-        assertTrue(Snowplow.getTrackers().isEmpty());
+        assertTrue(Snowplow.getInstancedTrackerNamespaces().isEmpty());
 
         Tracker tracker = Snowplow.createTracker("http://endpoint", "namespace", "appId");
         Tracker retrievedTracker = Snowplow.getTracker("namespace");
 
-        assertFalse(Snowplow.getTrackers().isEmpty());
+        assertFalse(Snowplow.getInstancedTrackerNamespaces().isEmpty());
         assertEquals(tracker, retrievedTracker);
         assertEquals("namespace", tracker.getNamespace());
         assertEquals("appId", tracker.getAppId());
@@ -87,6 +92,7 @@ public class SnowplowTest {
 
         Snowplow.setDefaultTracker(tracker2);
         assertEquals(tracker2, Snowplow.getDefaultTracker());
+        assertEquals(2, Snowplow.getInstancedTrackerNamespaces().size());
     }
 
     @Test
@@ -109,7 +115,7 @@ public class SnowplowTest {
         Snowplow.registerTracker(tracker);
 
         assertEquals(tracker, Snowplow.getDefaultTracker());
-        assertEquals(1, Snowplow.getTrackers().size());
+        assertEquals(1, Snowplow.getInstancedTrackerNamespaces().size());
     }
 
     @Test
@@ -119,7 +125,7 @@ public class SnowplowTest {
 
         Snowplow.setDefaultTracker(tracker);
 
-        assertEquals(1, Snowplow.getTrackers().size());
+        assertEquals(1, Snowplow.getInstancedTrackerNamespaces().size());
         assertEquals("new_tracker", Snowplow.getDefaultTracker().getNamespace());
     }
 
@@ -133,7 +139,7 @@ public class SnowplowTest {
         Tracker tracker = Snowplow.createTracker(trackerConfig, networkConfig);
         Tracker retrievedTracker = Snowplow.getTracker("namespace");
 
-        assertFalse(Snowplow.getTrackers().isEmpty());
+        assertFalse(Snowplow.getInstancedTrackerNamespaces().isEmpty());
         assertEquals(tracker, retrievedTracker);
         assertEquals("namespace", tracker.getNamespace());
         assertEquals("appId", tracker.getAppId());

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
@@ -128,7 +128,7 @@ public class SnowplowTest {
         TrackerConfiguration trackerConfig = new TrackerConfiguration("namespace", "appId")
                 .base64Encoded(false)
                 .platform(DevicePlatform.Desktop);
-        NetworkConfiguration networkConfig = new NetworkConfiguration().collectorUrl("http://collector-endpoint");
+        NetworkConfiguration networkConfig = new NetworkConfiguration("http://collector-endpoint");
 
         Tracker tracker = Snowplow.createTracker(trackerConfig, networkConfig);
         Tracker retrievedTracker = Snowplow.getTracker("namespace");

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
@@ -31,7 +31,7 @@ public class SnowplowTest {
     public void createsAndRetrievesATracker() {
         assertTrue(Snowplow.getInstancedTrackerNamespaces().isEmpty());
 
-        Tracker tracker = Snowplow.createTracker("http://endpoint", "namespace", "appId");
+        Tracker tracker = Snowplow.createTracker("namespace", "http://endpoint", "appId");
         Tracker retrievedTracker = Snowplow.getTracker("namespace");
 
         assertFalse(Snowplow.getInstancedTrackerNamespaces().isEmpty());
@@ -44,8 +44,8 @@ public class SnowplowTest {
     @Test
     public void preventsDuplicateNamespaces() {
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            Snowplow.createTracker("http://endpoint", "namespace", "appId");
-            Snowplow.createTracker("http://endpoint2", "namespace", "appId2");
+            Snowplow.createTracker("namespace", "http://endpoint", "appId");
+            Snowplow.createTracker("namespace", "http://collector", "appId2");
         });
 
         assertEquals("Tracker with this namespace already exists.", exception.getMessage());
@@ -53,11 +53,11 @@ public class SnowplowTest {
 
     @Test
     public void deletesStoredTracker() {
-        Snowplow.createTracker("http://endpoint", "namespace", "appId");
+        Snowplow.createTracker("namespace", "http://endpoint", "appId");
         boolean result = Snowplow.removeTracker("namespace");
         assertTrue(result);
 
-        Tracker tracker = Snowplow.createTracker("http://endpoint", "namespace2", "appId");
+        Tracker tracker = Snowplow.createTracker("namespace2", "http://endpoint", "appId");
         boolean result2 = Snowplow.removeTracker(tracker);
         assertTrue(result2);
     }
@@ -78,10 +78,10 @@ public class SnowplowTest {
     public void setsDefaultTrackerFromObject() {
         assertNull(Snowplow.getDefaultTracker());
 
-        Tracker tracker = Snowplow.createTracker("http://endpoint", "namespace", "appId");
+        Tracker tracker = Snowplow.createTracker("namespace", "http://endpoint", "appId");
         assertEquals(tracker, Snowplow.getDefaultTracker());
 
-        Tracker tracker2 = Snowplow.createTracker("http://endpoint", "namespace2", "appId");
+        Tracker tracker2 = Snowplow.createTracker("namespace2", "http://endpoint", "appId");
         // The first tracker is still the default
         assertEquals(tracker, Snowplow.getDefaultTracker());
 
@@ -94,8 +94,8 @@ public class SnowplowTest {
     public void setsDefaultTrackerFromNamespace() {
         assertNull(Snowplow.getDefaultTracker());
 
-        Snowplow.createTracker("http://endpoint", "namespace", "appId");
-        Tracker tracker2 = Snowplow.createTracker("http://endpoint", "namespace2", "appId");
+        Snowplow.createTracker("namespace", "http://endpoint", "appId");
+        Tracker tracker2 = Snowplow.createTracker("namespace2", "http://endpoint", "appId");
 
         boolean result = Snowplow.setDefaultTracker("namespace2");
         assertTrue(result);

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
@@ -12,7 +12,11 @@
  */
 package com.snowplowanalytics.snowplow.tracker;
 
+import com.snowplowanalytics.snowplow.tracker.configuration.EmitterConfiguration;
+import com.snowplowanalytics.snowplow.tracker.configuration.NetworkConfiguration;
+import com.snowplowanalytics.snowplow.tracker.configuration.TrackerConfiguration;
 import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
+import com.snowplowanalytics.snowplow.tracker.emitter.Emitter;
 import org.junit.After;
 import org.junit.Test;
 
@@ -82,5 +86,23 @@ public class SnowplowTest {
         Snowplow.registerTracker(tracker);
         assertEquals(tracker, Snowplow.getDefaultTracker());
         assertEquals(1, Snowplow.getTrackers().size());
+    }
+
+    @Test
+    public void createsTrackerFromConfigs() {
+        TrackerConfiguration trackerConfig = new TrackerConfiguration("namespace", "appId");
+        EmitterConfiguration emitterConfig = new EmitterConfiguration();
+        NetworkConfiguration networkConfig = new NetworkConfiguration().collectorUrl("http://collector-endpoint");
+
+        BatchEmitter emitter = new BatchEmitter(emitterConfig, networkConfig);
+
+//        Tracker tracker = Snowplow.createTracker(trackerConfig, emitterConfig, networkConfig);
+//        Tracker retrievedTracker = Snowplow.getTracker("namespace");
+//
+//        assertFalse(Snowplow.getTrackers().isEmpty());
+//        assertEquals(tracker, retrievedTracker);
+//        assertEquals("namespace", tracker.getNamespace());
+//        assertEquals("appId", tracker.getAppId());
+//        assertTrue(tracker.getBase64Encoded());
     }
 }

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2014-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.tracker;
+
+import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SnowplowTest {
+
+    @After
+    public void cleanUp(){
+        Snowplow.reset();
+    }
+
+    @Test
+    public void createsAndRetrievesATracker() {
+        assertTrue(Snowplow.getTrackers().isEmpty());
+
+        Tracker tracker = Snowplow.createTracker("http://endpoint", "namespace", "appId");
+        Tracker retrievedTracker = Snowplow.getTracker("namespace");
+
+        assertFalse(Snowplow.getTrackers().isEmpty());
+        assertEquals(tracker, retrievedTracker);
+        assertEquals("namespace", tracker.getNamespace());
+        assertEquals("appId", tracker.getAppId());
+        assertTrue(tracker.getBase64Encoded());
+    }
+
+    @Test
+    public void preventsDuplicateNamespaces() {
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            Snowplow.createTracker("http://endpoint", "namespace", "appId");
+            Snowplow.createTracker("http://endpoint2", "namespace", "appId2");
+        });
+
+        assertEquals("Tracker with this namespace already exists.", exception.getMessage());
+    }
+
+    @Test
+    public void deletesStoredTracker() {
+        Snowplow.createTracker("http://endpoint", "namespace", "appId");
+        boolean result = Snowplow.removeTracker("namespace");
+        assertTrue(result);
+
+        Tracker tracker = Snowplow.createTracker("http://endpoint", "namespace2", "appId");
+        boolean result2 = Snowplow.removeTracker(tracker);
+        assertTrue(result2);
+    }
+
+    @Test
+    public void hasDefaultTracker() {
+        assertNull(Snowplow.getDefaultTracker());
+
+        Tracker tracker = Snowplow.createTracker("http://endpoint", "namespace", "appId");
+        assertEquals(tracker, Snowplow.getDefaultTracker());
+
+        Tracker tracker2 = Snowplow.createTracker("http://endpoint", "namespace2", "appId");
+        assertEquals(tracker, Snowplow.getDefaultTracker());
+
+        Snowplow.setDefaultTracker(tracker2);
+        assertEquals(tracker2, Snowplow.getDefaultTracker());
+    }
+
+    @Test
+    public void registersATrackerMadeWithoutSnowplowClass() {
+        BatchEmitter emitter = BatchEmitter.builder().url("http://collector").build();
+        Tracker tracker = new Tracker.TrackerBuilder(emitter, "namespace", "appId").build();
+
+        Snowplow.registerTracker(tracker);
+        assertEquals(tracker, Snowplow.getDefaultTracker());
+        assertEquals(1, Snowplow.getTrackers().size());
+    }
+}

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
@@ -12,11 +12,9 @@
  */
 package com.snowplowanalytics.snowplow.tracker;
 
-import com.snowplowanalytics.snowplow.tracker.configuration.EmitterConfiguration;
 import com.snowplowanalytics.snowplow.tracker.configuration.NetworkConfiguration;
 import com.snowplowanalytics.snowplow.tracker.configuration.TrackerConfiguration;
 import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
-import com.snowplowanalytics.snowplow.tracker.emitter.Emitter;
 import org.junit.After;
 import org.junit.Test;
 
@@ -91,18 +89,15 @@ public class SnowplowTest {
     @Test
     public void createsTrackerFromConfigs() {
         TrackerConfiguration trackerConfig = new TrackerConfiguration("namespace", "appId");
-        EmitterConfiguration emitterConfig = new EmitterConfiguration();
         NetworkConfiguration networkConfig = new NetworkConfiguration().collectorUrl("http://collector-endpoint");
 
-        BatchEmitter emitter = new BatchEmitter(emitterConfig, networkConfig);
+        Tracker tracker = Snowplow.createTracker(trackerConfig, networkConfig);
+        Tracker retrievedTracker = Snowplow.getTracker("namespace");
 
-//        Tracker tracker = Snowplow.createTracker(trackerConfig, emitterConfig, networkConfig);
-//        Tracker retrievedTracker = Snowplow.getTracker("namespace");
-//
-//        assertFalse(Snowplow.getTrackers().isEmpty());
-//        assertEquals(tracker, retrievedTracker);
-//        assertEquals("namespace", tracker.getNamespace());
-//        assertEquals("appId", tracker.getAppId());
-//        assertTrue(tracker.getBase64Encoded());
+        assertFalse(Snowplow.getTrackers().isEmpty());
+        assertEquals(tracker, retrievedTracker);
+        assertEquals("namespace", tracker.getNamespace());
+        assertEquals("appId", tracker.getAppId());
+        assertTrue(tracker.getBase64Encoded());
     }
 }

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 // JUnit
+import com.snowplowanalytics.snowplow.tracker.configuration.SubjectConfiguration;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
@@ -110,5 +111,29 @@ public class SubjectTest {
         expected.put("uid", "user1");
 
         assertEquals(expected, subject.getSubject());
+    }
+
+    @Test
+    public void testCreateWithBuilder() {
+        Subject subject = Subject.builder()
+                .domainSessionId("domain session ID")
+                .viewPort(123, 456)
+                .language("en")
+                .build();
+
+        assertEquals("domain session ID", subject.getSubject().get("sid"));
+        assertEquals("123x456", subject.getSubject().get("vp"));
+        assertEquals("en", subject.getSubject().get("lang"));
+    }
+
+    @Test
+    public void testCreateFromConfig() {
+        SubjectConfiguration subjectConfig = new SubjectConfiguration()
+                .ipAddress("xxx.000.xxx.111")
+                .useragent("Mac OS");
+        Subject subject = new Subject(subjectConfig);
+
+        assertEquals("xxx.000.xxx.111", subject.getSubject().get("ip"));
+        assertEquals("Mac OS", subject.getSubject().get("ua"));
     }
 }

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -15,6 +15,9 @@ package com.snowplowanalytics.snowplow.tracker;
 import java.util.*;
 import static java.util.Collections.singletonList;
 
+import com.snowplowanalytics.snowplow.tracker.configuration.NetworkConfiguration;
+import com.snowplowanalytics.snowplow.tracker.configuration.TrackerConfiguration;
+import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -560,6 +563,18 @@ public class TrackerTest {
     }
 
     // --- Tracker Setter & Getter Tests
+
+    @Test
+    public void testCreateWithConfiguration() {
+        TrackerConfiguration trackerConfig = new TrackerConfiguration("namespace", "appId");
+        trackerConfig.base64Encoded(false);
+        trackerConfig.platform(DevicePlatform.General);
+        BatchEmitter emitter = BatchEmitter.builder().url("http://collector").build();
+        Tracker tracker = new Tracker(trackerConfig, emitter);
+
+        assertEquals("namespace", tracker.getNamespace());
+        assertEquals(emitter, tracker.getEmitter());
+    }
 
     @Test
     public void testGetTrackerVersion() {

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
@@ -251,7 +251,7 @@ public class BatchEmitterTest {
 
     @Test
     public void createEmitterWithConfiguration() {
-        NetworkConfiguration networkConfig = new NetworkConfiguration().collectorUrl("http://endpoint");
+        NetworkConfiguration networkConfig = new NetworkConfiguration("http://endpoint");
         EmitterConfiguration emitterConfig = new EmitterConfiguration().batchSize(5);
         BatchEmitter emitter = new BatchEmitter(networkConfig, emitterConfig);
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitterTest.java
@@ -15,6 +15,8 @@ package com.snowplowanalytics.snowplow.tracker.emitter;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import com.snowplowanalytics.snowplow.tracker.configuration.EmitterConfiguration;
+import com.snowplowanalytics.snowplow.tracker.configuration.NetworkConfiguration;
 import com.snowplowanalytics.snowplow.tracker.constants.Parameter;
 import org.junit.Assert;
 import org.junit.Before;
@@ -30,7 +32,6 @@ public class BatchEmitterTest {
     private MockHttpClientAdapter mockHttpClientAdapter;
     private BatchEmitter emitter;
 
-    // MockHttpClientAdapter always returns 200
     public static class MockHttpClientAdapter implements HttpClientAdapter {
         private final int statusCode;
         public boolean isGetCalled = false;
@@ -246,6 +247,15 @@ public class BatchEmitterTest {
             emitter.add(payload);
         }
         Assert.assertEquals(20, emitter.getBuffer().size());
+    }
+
+    @Test
+    public void createEmitterWithConfiguration() {
+        NetworkConfiguration networkConfig = new NetworkConfiguration().collectorUrl("http://endpoint");
+        EmitterConfiguration emitterConfig = new EmitterConfiguration().batchSize(5);
+        BatchEmitter emitter = new BatchEmitter(networkConfig, emitterConfig);
+
+        Assert.assertEquals(5, emitter.getBatchSize());
     }
 
     @Test


### PR DESCRIPTION
This PR adds a couple of API improvements. A `Snowplow` class has been added with static methods for creating and managing multiple trackers.

Also, configuration classes have been added to bring this tracker more in line with the Android and C++ trackers. In conjunction with the Snowplow class, it's now very easy to create a tracker with default configuration, or to set custom choices.