### PR TITLE
Deprecate Builder classes (close #355)

### DIFF
--- a/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
+++ b/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
@@ -18,7 +18,6 @@ import com.snowplowanalytics.snowplow.tracker.Subject;
 import com.snowplowanalytics.snowplow.tracker.Tracker;
 import com.snowplowanalytics.snowplow.tracker.configuration.EmitterConfiguration;
 import com.snowplowanalytics.snowplow.tracker.configuration.NetworkConfiguration;
-import com.snowplowanalytics.snowplow.tracker.configuration.SubjectConfiguration;
 import com.snowplowanalytics.snowplow.tracker.configuration.TrackerConfiguration;
 import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
 import com.snowplowanalytics.snowplow.tracker.events.*;

--- a/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
+++ b/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
@@ -64,7 +64,7 @@ public class Main {
                 Collections.singletonMap("foo", "bar")));
 
         // This is an example of a eventSubject for adding user data
-        Subject eventSubject = new Subject(new SubjectConfiguration());
+        Subject eventSubject = new Subject();
         eventSubject.setUserId("example@snowplowanalytics.com");
         eventSubject.setLanguage("EN");
 

--- a/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
+++ b/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
@@ -13,9 +13,13 @@
 
 package com.snowplowanalytics;
 
-import com.snowplowanalytics.snowplow.tracker.DevicePlatform;
+import com.snowplowanalytics.snowplow.tracker.Snowplow;
 import com.snowplowanalytics.snowplow.tracker.Subject;
 import com.snowplowanalytics.snowplow.tracker.Tracker;
+import com.snowplowanalytics.snowplow.tracker.configuration.EmitterConfiguration;
+import com.snowplowanalytics.snowplow.tracker.configuration.NetworkConfiguration;
+import com.snowplowanalytics.snowplow.tracker.configuration.SubjectConfiguration;
+import com.snowplowanalytics.snowplow.tracker.configuration.TrackerConfiguration;
 import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
 import com.snowplowanalytics.snowplow.tracker.events.*;
 import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
@@ -42,17 +46,13 @@ public class Main {
         // the namespace to attach to events
         String namespace = "demo";
 
-        // build an emitter, this is used by the tracker to batch and schedule transmission of events
-        BatchEmitter emitter = BatchEmitter.builder()
-                .url(collectorEndpoint)
-                .batchSize(4) // send batches of 4 events. In production this number should be higher, depending on the size/event volume
-                .build();
+        // The easiest way to build a tracker is with configuration classes
+        TrackerConfiguration trackerConfig = new TrackerConfiguration(namespace, appId);
+        NetworkConfiguration networkConfig = new NetworkConfiguration(collectorEndpoint);
+        EmitterConfiguration emitterConfig = new EmitterConfiguration().batchSize(4); // send batches of 4 events. In production this number should be higher, depending on the size/event volume
 
-        // now we have the emitter, we need a tracker to turn our events into something a Snowplow collector can understand
-        final Tracker tracker = Tracker.builder(emitter, namespace, appId)
-            .base64(true)
-            .platform(DevicePlatform.ServerSideApp)
-            .build();
+        // We need a tracker to turn our events into something a Snowplow collector can understand
+        final Tracker tracker = Snowplow.createTracker(trackerConfig, networkConfig, emitterConfig);
 
         System.out.println("Sending events to " + collectorEndpoint);
         System.out.println("Using tracker version " + tracker.getTrackerVersion());
@@ -64,7 +64,7 @@ public class Main {
                 Collections.singletonMap("foo", "bar")));
 
         // This is an example of a eventSubject for adding user data
-        Subject eventSubject = Subject.builder().build();
+        Subject eventSubject = new Subject(new SubjectConfiguration());
         eventSubject.setUserId("example@snowplowanalytics.com");
         eventSubject.setLanguage("EN");
 
@@ -152,6 +152,7 @@ public class Main {
         tracker.track(structured);
 
         // Will close all threads and force send remaining events
+        BatchEmitter emitter = (BatchEmitter) tracker.getEmitter();
         emitter.close();
         Thread.sleep(5000);
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Snowplow.java
@@ -102,11 +102,11 @@ public class Snowplow {
      * Create a Snowplow tracker with default configuration by providing three parameters.
      *
      * @param namespace unique identifier for the Tracker instance
-     * @param collectorUrl collector endpoint
      * @param appId application ID
+     * @param collectorUrl collector endpoint
      * @return the created Tracker
      */
-    public static Tracker createTracker(String namespace, String collectorUrl, String appId) {
+    public static Tracker createTracker(String namespace, String appId, String collectorUrl) {
         TrackerConfiguration trackerConfig = new TrackerConfiguration(namespace, appId);
         NetworkConfiguration networkConfig = new NetworkConfiguration(collectorUrl);
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
@@ -53,15 +53,20 @@ public class Subject {
      * @param subject The subject from which the map is copied.
      */
     public Subject(Subject subject){
-      this.standardPairs.putAll(subject.getSubject());
+        standardPairs.putAll(subject.getSubject());
     }
 
+    /**
+     * @deprecated Use SubjectConfiguration class instead
+     * @return a SubjectBuilder object
+     */
     public static SubjectBuilder builder() {
         return new SubjectBuilder();
     }
 
     /**
      * Builder for the Subject
+     * @deprecated Use SubjectConfiguration class instead
      */
     public static class SubjectBuilder {
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
@@ -60,6 +60,7 @@ public class Subject {
      * @deprecated Use SubjectConfiguration class instead
      * @return a SubjectBuilder object
      */
+    @Deprecated
     public static SubjectBuilder builder() {
         return new SubjectBuilder();
     }
@@ -68,6 +69,7 @@ public class Subject {
      * Builder for the Subject
      * @deprecated Use SubjectConfiguration class instead
      */
+    @Deprecated
     public static class SubjectBuilder {
 
         private String userId; // Optional

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Subject.java
@@ -49,6 +49,13 @@ public class Subject {
     }
 
     /**
+     * Creates a Subject instance with default configuration (only the timezone is set).
+     */
+    public Subject() {
+        this(new SubjectConfiguration());
+    }
+
+    /**
      * Creates a new {@link Subject} object based on the map of another {@link Subject} object.
      * @param subject The subject from which the map is copied.
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -74,6 +74,7 @@ public class Tracker {
      * Builder for the Tracker
      * @deprecated Use TrackerConfiguration class instead
      */
+    @Deprecated
     public static class TrackerBuilder {
 
         private final Emitter emitter; // Required
@@ -145,6 +146,7 @@ public class Tracker {
      * @param appId application ID
      * @return TrackerBuilder object
      */
+    @Deprecated
     public static TrackerBuilder builder(Emitter emitter, String namespace, String appId) {
         return new TrackerBuilder(emitter, namespace, appId);
     }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -71,17 +71,6 @@ public class Tracker {
     }
 
     /**
-     * Creates a new Snowplow Tracker.
-     *
-     * @param namespace unique tracker namespace
-     * @param appId application ID
-     * @param emitter an Emitter
-     */
-    public Tracker(String namespace, String appId, Emitter emitter) {
-        this(new TrackerConfiguration(namespace, appId), emitter);
-    }
-
-    /**
      * Builder for the Tracker
      * @deprecated Use TrackerConfiguration class instead
      */

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -37,17 +37,6 @@ public class Tracker {
      *
      * @param trackerConfig a TrackerConfiguration object
      * @param emitter an Emitter
-     *
-     */
-    public Tracker(TrackerConfiguration trackerConfig, Emitter emitter) {
-        this(trackerConfig, emitter, null);
-    }
-
-    /**
-     * Creates a new Snowplow Tracker.
-     *
-     * @param trackerConfig a TrackerConfiguration object
-     * @param emitter an Emitter
      * @param subject a Subject
      *
      */
@@ -71,7 +60,30 @@ public class Tracker {
     }
 
     /**
+     * Creates a new Snowplow Tracker.
+     *
+     * @param trackerConfig a TrackerConfiguration object
+     * @param emitter an Emitter
+     *
+     */
+    public Tracker(TrackerConfiguration trackerConfig, Emitter emitter) {
+        this(trackerConfig, emitter, null);
+    }
+
+    /**
+     * Creates a new Snowplow Tracker.
+     *
+     * @param namespace unique tracker namespace
+     * @param appId application ID
+     * @param emitter an Emitter
+     */
+    public Tracker(String namespace, String appId, Emitter emitter) {
+        this(new TrackerConfiguration(namespace, appId), emitter);
+    }
+
+    /**
      * Builder for the Tracker
+     * @deprecated Use TrackerConfiguration class instead
      */
     public static class TrackerBuilder {
 
@@ -137,6 +149,13 @@ public class Tracker {
         }
     }
 
+    /**
+     * @deprecated Use TrackerConfiguration class instead
+     * @param emitter Emitter object
+     * @param namespace unique tracker namespace
+     * @param appId application ID
+     * @return TrackerBuilder object
+     */
     public static TrackerBuilder builder(Emitter emitter, String namespace, String appId) {
         return new TrackerBuilder(emitter, namespace, appId);
     }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -66,6 +66,7 @@ public class BatchEmitter implements Emitter, Closeable {
      * @deprecated Use NetworkConfiguration/EmitterConfiguration classes instead
      * @param <T> Builder
      */
+    @Deprecated
     public static abstract class Builder<T extends Builder<T>> {
         protected abstract T self();
 
@@ -227,6 +228,7 @@ public class BatchEmitter implements Emitter, Closeable {
      * @deprecated Use NetworkConfiguration/EmitterConfiguration classes instead
      * @return Builder object
      */
+    @Deprecated
     public static Builder<?> builder() {
         return new Builder2();
     }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -64,7 +64,7 @@ public class BatchEmitter implements Emitter, Closeable {
 
     /**
      * @deprecated Use EmitterConfiguration class instead
-     * @param <T>
+     * @param <T> Builder
      */
     public static abstract class Builder<T extends Builder<T>> {
         protected abstract T self();

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -63,7 +63,7 @@ public class BatchEmitter implements Emitter, Closeable {
     private final EmitterCallback callback;
 
     /**
-     * @deprecated Use EmitterConfiguration class instead
+     * @deprecated Use NetworkConfiguration/EmitterConfiguration classes instead
      * @param <T> Builder
      */
     public static abstract class Builder<T extends Builder<T>> {
@@ -224,7 +224,7 @@ public class BatchEmitter implements Emitter, Closeable {
     }
 
     /**
-     * @deprecated Use EmitterConfiguration class instead
+     * @deprecated Use NetworkConfiguration/EmitterConfiguration classes instead
      * @return Builder object
      */
     public static Builder<?> builder() {

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/BatchEmitter.java
@@ -62,6 +62,10 @@ public class BatchEmitter implements Emitter, Closeable {
     private final Map<Integer, Boolean> customRetryForStatusCodes;
     private final EmitterCallback callback;
 
+    /**
+     * @deprecated Use EmitterConfiguration class instead
+     * @param <T>
+     */
     public static abstract class Builder<T extends Builder<T>> {
         protected abstract T self();
 
@@ -219,6 +223,10 @@ public class BatchEmitter implements Emitter, Closeable {
         }
     }
 
+    /**
+     * @deprecated Use EmitterConfiguration class instead
+     * @return Builder object
+     */
     public static Builder<?> builder() {
         return new Builder2();
     }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/EventStore.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/EventStore.java
@@ -49,6 +49,7 @@ public interface EventStore {
      *
      * @param needRetry if another attempt should be made to send the events
      * @param batchId the ID of the batch of events
+     * @return list of TrackerPayloads
      */
     List<TrackerPayload> cleanupAfterSendingAttempt(boolean needRetry, long batchId);
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/AbstractHttpClientAdapter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/AbstractHttpClientAdapter.java
@@ -32,6 +32,7 @@ public abstract class AbstractHttpClientAdapter implements HttpClientAdapter {
      * @deprecated Create HttpClientAdapter directly instead
      * @param <T> Builder
      */
+    @Deprecated
     public static abstract class Builder<T extends Builder<T>> {
 
         private String url; // Required
@@ -60,6 +61,7 @@ public abstract class AbstractHttpClientAdapter implements HttpClientAdapter {
      * @deprecated Create HttpClientAdapter directly instead
      * @return Builder object
      */
+    @Deprecated
     public static Builder<?> builder() {
         return new Builder2();
     }
@@ -68,6 +70,7 @@ public abstract class AbstractHttpClientAdapter implements HttpClientAdapter {
      * @deprecated Create HttpClientAdapter directly instead
      * @param builder Builder object
      */
+    @Deprecated
     protected AbstractHttpClientAdapter(Builder<?> builder) {
         // Precondition checks
         if (!Utils.isValidUrl(builder.url)) {

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/AbstractHttpClientAdapter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/AbstractHttpClientAdapter.java
@@ -30,7 +30,7 @@ public abstract class AbstractHttpClientAdapter implements HttpClientAdapter {
 
     /**
      * @deprecated Create HttpClientAdapter directly instead
-     * @param <T>
+     * @param <T> Builder
      */
     public static abstract class Builder<T extends Builder<T>> {
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/AbstractHttpClientAdapter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/AbstractHttpClientAdapter.java
@@ -24,6 +24,14 @@ public abstract class AbstractHttpClientAdapter implements HttpClientAdapter {
 
     protected final String url;
 
+    public AbstractHttpClientAdapter(String url) {
+        this.url = url.replaceFirst("/*$", "");
+    }
+
+    /**
+     * @deprecated Create HttpClientAdapter directly instead
+     * @param <T>
+     */
     public static abstract class Builder<T extends Builder<T>> {
 
         private String url; // Required
@@ -48,10 +56,18 @@ public abstract class AbstractHttpClientAdapter implements HttpClientAdapter {
         }
     }
 
+    /**
+     * @deprecated Create HttpClientAdapter directly instead
+     * @return Builder object
+     */
     public static Builder<?> builder() {
         return new Builder2();
     }
 
+    /**
+     * @deprecated Create HttpClientAdapter directly instead
+     * @param builder Builder object
+     */
     protected AbstractHttpClientAdapter(Builder<?> builder) {
         // Precondition checks
         if (!Utils.isValidUrl(builder.url)) {

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/ApacheHttpClientAdapter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/ApacheHttpClientAdapter.java
@@ -35,6 +35,19 @@ public class ApacheHttpClientAdapter extends AbstractHttpClientAdapter {
     private static final Logger LOGGER = LoggerFactory.getLogger(ApacheHttpClientAdapter.class);
     private CloseableHttpClient httpClient;
 
+    public ApacheHttpClientAdapter(String url, CloseableHttpClient httpClient) {
+        super(url);
+
+        // Precondition checks
+        Objects.requireNonNull(httpClient);
+
+        this.httpClient = httpClient;
+    }
+
+    /**
+     * @deprecated Create HttpClientAdapter directly instead
+     * @param <T>
+     */
     public static abstract class Builder<T extends Builder<T>> extends AbstractHttpClientAdapter.Builder<T> {
 
         private CloseableHttpClient httpClient; // Required
@@ -60,10 +73,18 @@ public class ApacheHttpClientAdapter extends AbstractHttpClientAdapter {
         }
     }
 
+    /**
+     * @deprecated Create HttpClientAdapter directly instead
+     * @return Builder object
+     */
     public static Builder<?> builder() {
         return new Builder2();
     }
 
+    /**
+     * @deprecated Create HttpClientAdapter directly instead
+     * @param builder Builder object
+     */
     protected ApacheHttpClientAdapter(Builder<?> builder) {
         super(builder);
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/ApacheHttpClientAdapter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/ApacheHttpClientAdapter.java
@@ -46,7 +46,7 @@ public class ApacheHttpClientAdapter extends AbstractHttpClientAdapter {
 
     /**
      * @deprecated Create HttpClientAdapter directly instead
-     * @param <T>
+     * @param <T> Builder
      */
     public static abstract class Builder<T extends Builder<T>> extends AbstractHttpClientAdapter.Builder<T> {
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/ApacheHttpClientAdapter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/ApacheHttpClientAdapter.java
@@ -48,6 +48,7 @@ public class ApacheHttpClientAdapter extends AbstractHttpClientAdapter {
      * @deprecated Create HttpClientAdapter directly instead
      * @param <T> Builder
      */
+    @Deprecated
     public static abstract class Builder<T extends Builder<T>> extends AbstractHttpClientAdapter.Builder<T> {
 
         private CloseableHttpClient httpClient; // Required
@@ -77,6 +78,7 @@ public class ApacheHttpClientAdapter extends AbstractHttpClientAdapter {
      * @deprecated Create HttpClientAdapter directly instead
      * @return Builder object
      */
+    @Deprecated
     public static Builder<?> builder() {
         return new Builder2();
     }
@@ -85,6 +87,7 @@ public class ApacheHttpClientAdapter extends AbstractHttpClientAdapter {
      * @deprecated Create HttpClientAdapter directly instead
      * @param builder Builder object
      */
+    @Deprecated
     protected ApacheHttpClientAdapter(Builder<?> builder) {
         super(builder);
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/OkHttpClientAdapter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/OkHttpClientAdapter.java
@@ -49,6 +49,7 @@ public class OkHttpClientAdapter extends AbstractHttpClientAdapter {
      * @deprecated Create HttpClientAdapter directly instead
      * @param <T> Builder
      */
+    @Deprecated
     public static abstract class Builder<T extends Builder<T>> extends AbstractHttpClientAdapter.Builder<T> {
 
         private OkHttpClient httpClient; // Required
@@ -78,6 +79,7 @@ public class OkHttpClientAdapter extends AbstractHttpClientAdapter {
      * @deprecated Create HttpClientAdapter directly instead
      * @return Builder object
      */
+    @Deprecated
     public static Builder<?> builder() {
         return new Builder2();
     }
@@ -86,6 +88,7 @@ public class OkHttpClientAdapter extends AbstractHttpClientAdapter {
      * @deprecated Create HttpClientAdapter directly instead
      * @param builder Builder object
      */
+    @Deprecated
     protected OkHttpClientAdapter(Builder<?> builder) {
         super(builder);
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/OkHttpClientAdapter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/OkHttpClientAdapter.java
@@ -47,7 +47,7 @@ public class OkHttpClientAdapter extends AbstractHttpClientAdapter {
 
     /**
      * @deprecated Create HttpClientAdapter directly instead
-     * @param <T>
+     * @param <T> Builder
      */
     public static abstract class Builder<T extends Builder<T>> extends AbstractHttpClientAdapter.Builder<T> {
 

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/OkHttpClientAdapter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/OkHttpClientAdapter.java
@@ -36,6 +36,19 @@ public class OkHttpClientAdapter extends AbstractHttpClientAdapter {
     private final MediaType JSON = MediaType.get(Constants.POST_CONTENT_TYPE);
     private OkHttpClient httpClient;
 
+    public OkHttpClientAdapter(String url, OkHttpClient httpClient) {
+        super(url);
+
+        // Precondition checks
+        Objects.requireNonNull(httpClient);
+
+        this.httpClient = httpClient;
+    }
+
+    /**
+     * @deprecated Create HttpClientAdapter directly instead
+     * @param <T>
+     */
     public static abstract class Builder<T extends Builder<T>> extends AbstractHttpClientAdapter.Builder<T> {
 
         private OkHttpClient httpClient; // Required
@@ -61,10 +74,18 @@ public class OkHttpClientAdapter extends AbstractHttpClientAdapter {
         }
     }
 
+    /**
+     * @deprecated Create HttpClientAdapter directly instead
+     * @return Builder object
+     */
     public static Builder<?> builder() {
         return new Builder2();
     }
 
+    /**
+     * @deprecated Create HttpClientAdapter directly instead
+     * @param builder Builder object
+     */
     protected OkHttpClientAdapter(Builder<?> builder) {
         super(builder);
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
@@ -13,8 +13,10 @@
 package com.snowplowanalytics.snowplow.tracker;
 
 import com.snowplowanalytics.snowplow.tracker.configuration.NetworkConfiguration;
+import com.snowplowanalytics.snowplow.tracker.configuration.SubjectConfiguration;
 import com.snowplowanalytics.snowplow.tracker.configuration.TrackerConfiguration;
 import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
+import com.snowplowanalytics.snowplow.tracker.events.SelfDescribing;
 import org.junit.After;
 import org.junit.Test;
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
@@ -64,8 +64,8 @@ public class SnowplowTest {
 
     @Test
     public void doesNotDeleteUnregisteredTracker() {
-        BatchEmitter emitter = BatchEmitter.builder().url("http://collector").build();
-        Tracker tracker = new Tracker.TrackerBuilder(emitter, "namespace", "appId").build();
+        BatchEmitter emitter = new BatchEmitter(new NetworkConfiguration("http://collector"));
+        Tracker tracker = new Tracker(new TrackerConfiguration("namespace", "appId"), emitter);
 
         boolean result = Snowplow.removeTracker(tracker);
         assertFalse(result);
@@ -104,8 +104,8 @@ public class SnowplowTest {
 
     @Test
     public void registersATrackerMadeWithoutSnowplowClass() {
-        BatchEmitter emitter = BatchEmitter.builder().url("http://collector").build();
-        Tracker tracker = new Tracker.TrackerBuilder(emitter, "namespace", "appId").build();
+        BatchEmitter emitter = new BatchEmitter(new NetworkConfiguration("http://collector"));
+        Tracker tracker = new Tracker(new TrackerConfiguration("namespace", "appId"), emitter);
 
         Snowplow.registerTracker(tracker);
 
@@ -115,8 +115,8 @@ public class SnowplowTest {
 
     @Test
     public void settingNewDefaultTrackerRegistersIt() {
-        BatchEmitter emitter = BatchEmitter.builder().url("http://collector").build();
-        Tracker tracker = new Tracker.TrackerBuilder(emitter, "new_tracker", "appId").build();
+        BatchEmitter emitter = new BatchEmitter(new NetworkConfiguration("http://collector"));
+        Tracker tracker = new Tracker(new TrackerConfiguration("new_tracker", "appId"), emitter);
 
         Snowplow.setDefaultTracker(tracker);
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
@@ -13,10 +13,8 @@
 package com.snowplowanalytics.snowplow.tracker;
 
 import com.snowplowanalytics.snowplow.tracker.configuration.NetworkConfiguration;
-import com.snowplowanalytics.snowplow.tracker.configuration.SubjectConfiguration;
 import com.snowplowanalytics.snowplow.tracker.configuration.TrackerConfiguration;
 import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
-import com.snowplowanalytics.snowplow.tracker.events.SelfDescribing;
 import org.junit.After;
 import org.junit.Test;
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SnowplowTest.java
@@ -31,7 +31,7 @@ public class SnowplowTest {
     public void createsAndRetrievesATracker() {
         assertTrue(Snowplow.getInstancedTrackerNamespaces().isEmpty());
 
-        Tracker tracker = Snowplow.createTracker("namespace", "http://endpoint", "appId");
+        Tracker tracker = Snowplow.createTracker("namespace", "appId", "http://endpoint");
         Tracker retrievedTracker = Snowplow.getTracker("namespace");
 
         assertFalse(Snowplow.getInstancedTrackerNamespaces().isEmpty());
@@ -44,8 +44,8 @@ public class SnowplowTest {
     @Test
     public void preventsDuplicateNamespaces() {
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            Snowplow.createTracker("namespace", "http://endpoint", "appId");
-            Snowplow.createTracker("namespace", "http://collector", "appId2");
+            Snowplow.createTracker("namespace", "appId", "http://endpoint");
+            Snowplow.createTracker("namespace", "appId2", "http://collector");
         });
 
         assertEquals("Tracker with this namespace already exists.", exception.getMessage());
@@ -53,11 +53,11 @@ public class SnowplowTest {
 
     @Test
     public void deletesStoredTracker() {
-        Snowplow.createTracker("namespace", "http://endpoint", "appId");
+        Snowplow.createTracker("namespace", "appId", "http://endpoint");
         boolean result = Snowplow.removeTracker("namespace");
         assertTrue(result);
 
-        Tracker tracker = Snowplow.createTracker("namespace2", "http://endpoint", "appId");
+        Tracker tracker = Snowplow.createTracker("namespace2", "appId", "http://endpoint");
         boolean result2 = Snowplow.removeTracker(tracker);
         assertTrue(result2);
     }
@@ -78,10 +78,10 @@ public class SnowplowTest {
     public void setsDefaultTrackerFromObject() {
         assertNull(Snowplow.getDefaultTracker());
 
-        Tracker tracker = Snowplow.createTracker("namespace", "http://endpoint", "appId");
+        Tracker tracker = Snowplow.createTracker("namespace", "appId", "http://endpoint");
         assertEquals(tracker, Snowplow.getDefaultTracker());
 
-        Tracker tracker2 = Snowplow.createTracker("namespace2", "http://endpoint", "appId");
+        Tracker tracker2 = Snowplow.createTracker("namespace2", "appId", "http://endpoint");
         // The first tracker is still the default
         assertEquals(tracker, Snowplow.getDefaultTracker());
 
@@ -94,8 +94,8 @@ public class SnowplowTest {
     public void setsDefaultTrackerFromNamespace() {
         assertNull(Snowplow.getDefaultTracker());
 
-        Snowplow.createTracker("namespace", "http://endpoint", "appId");
-        Tracker tracker2 = Snowplow.createTracker("namespace2", "http://endpoint", "appId");
+        Snowplow.createTracker("namespace", "appId", "http://endpoint");
+        Tracker tracker2 = Snowplow.createTracker("namespace2", "appId", "http://endpoint");
 
         boolean result = Snowplow.setDefaultTracker("namespace2");
         assertTrue(result);

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
@@ -25,84 +25,84 @@ public class SubjectTest {
 
     @Test
     public void testSetUserId() {
-        Subject subject = new Subject(new SubjectConfiguration());
+        Subject subject = new Subject();
         subject.setUserId("user1");
         assertEquals("user1", subject.getSubject().get("uid"));
     }
 
     @Test
     public void testSetScreenResolution() {
-        Subject subject = new Subject(new SubjectConfiguration());
+        Subject subject = new Subject();
         subject.setScreenResolution(100, 150);
         assertEquals("100x150", subject.getSubject().get("res"));
     }
 
     @Test
     public void testSetViewPort() {
-        Subject subject = new Subject(new SubjectConfiguration());
+        Subject subject = new Subject();
         subject.setViewPort(150, 100);
         assertEquals("150x100", subject.getSubject().get("vp"));
     }
 
     @Test
     public void testSetColorDepth() {
-        Subject subject = new Subject(new SubjectConfiguration());
+        Subject subject = new Subject();
         subject.setColorDepth(10);
         assertEquals("10", subject.getSubject().get("cd"));
     }
 
     @Test
     public void testSetTimezone2() {
-        Subject subject = new Subject(new SubjectConfiguration());
+        Subject subject = new Subject();
         subject.setTimezone("America/Toronto");
         assertEquals("America/Toronto", subject.getSubject().get("tz"));
     }
 
     @Test
     public void testSetLanguage() {
-        Subject subject = new Subject(new SubjectConfiguration());
+        Subject subject = new Subject();
         subject.setLanguage("EN");
         assertEquals("EN", subject.getSubject().get("lang"));
     }
 
     @Test
     public void testSetIpAddress() {
-        Subject subject = new Subject(new SubjectConfiguration());
+        Subject subject = new Subject();
         subject.setIpAddress("127.0.0.1");
         assertEquals("127.0.0.1", subject.getSubject().get("ip"));
     }
 
     @Test
     public void testSetUseragent() {
-        Subject subject = new Subject(new SubjectConfiguration());
+        Subject subject = new Subject();
         subject.setUseragent("useragent");
         assertEquals("useragent", subject.getSubject().get("ua"));
     }
 
     @Test
     public void testSetDomainUserId() {
-        Subject subject = new Subject(new SubjectConfiguration());
+        Subject subject = new Subject();
         subject.setDomainUserId("duid");
         assertEquals("duid", subject.getSubject().get("duid"));
     }
 
     @Test
     public void testSetNetworkUserId() {
-        Subject subject = new Subject(new SubjectConfiguration());
+        Subject subject = new Subject();
         subject.setNetworkUserId("nuid");
         assertEquals("nuid", subject.getSubject().get("tnuid"));
     }
 
     @Test
     public void testSetDomainSessionId() {
-        Subject subject = new Subject(new SubjectConfiguration());
+        Subject subject = new Subject();
         subject.setDomainSessionId("sessionid");
         assertEquals("sessionid", subject.getSubject().get("sid"));
     }
 
     @Test
     public void testGetSubject() {
-        Subject subject = new Subject(new SubjectConfiguration());
+        Subject subject = new Subject();
         Map<String, String> expected = new HashMap<>();
         subject.setTimezone("America/Toronto");
         subject.setUserId("user1");

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
@@ -25,84 +25,84 @@ public class SubjectTest {
 
     @Test
     public void testSetUserId() {
-        Subject subject = Subject.builder().build();
+        Subject subject = new Subject(new SubjectConfiguration());
         subject.setUserId("user1");
         assertEquals("user1", subject.getSubject().get("uid"));
     }
 
     @Test
     public void testSetScreenResolution() {
-        Subject subject = Subject.builder().build();
+        Subject subject = new Subject(new SubjectConfiguration());
         subject.setScreenResolution(100, 150);
         assertEquals("100x150", subject.getSubject().get("res"));
     }
 
     @Test
     public void testSetViewPort() {
-        Subject subject = Subject.builder().build();
+        Subject subject = new Subject(new SubjectConfiguration());
         subject.setViewPort(150, 100);
         assertEquals("150x100", subject.getSubject().get("vp"));
     }
 
     @Test
     public void testSetColorDepth() {
-        Subject subject = Subject.builder().build();
+        Subject subject = new Subject(new SubjectConfiguration());
         subject.setColorDepth(10);
         assertEquals("10", subject.getSubject().get("cd"));
     }
 
     @Test
     public void testSetTimezone2() {
-        Subject subject = Subject.builder().build();
+        Subject subject = new Subject(new SubjectConfiguration());
         subject.setTimezone("America/Toronto");
         assertEquals("America/Toronto", subject.getSubject().get("tz"));
     }
 
     @Test
     public void testSetLanguage() {
-        Subject subject = Subject.builder().build();
+        Subject subject = new Subject(new SubjectConfiguration());
         subject.setLanguage("EN");
         assertEquals("EN", subject.getSubject().get("lang"));
     }
 
     @Test
     public void testSetIpAddress() {
-        Subject subject = Subject.builder().build();
+        Subject subject = new Subject(new SubjectConfiguration());
         subject.setIpAddress("127.0.0.1");
         assertEquals("127.0.0.1", subject.getSubject().get("ip"));
     }
 
     @Test
     public void testSetUseragent() {
-        Subject subject = Subject.builder().build();
+        Subject subject = new Subject(new SubjectConfiguration());
         subject.setUseragent("useragent");
         assertEquals("useragent", subject.getSubject().get("ua"));
     }
 
     @Test
     public void testSetDomainUserId() {
-        Subject subject = Subject.builder().build();
+        Subject subject = new Subject(new SubjectConfiguration());
         subject.setDomainUserId("duid");
         assertEquals("duid", subject.getSubject().get("duid"));
     }
 
     @Test
     public void testSetNetworkUserId() {
-        Subject subject = Subject.builder().build();
+        Subject subject = new Subject(new SubjectConfiguration());
         subject.setNetworkUserId("nuid");
         assertEquals("nuid", subject.getSubject().get("tnuid"));
     }
 
     @Test
     public void testSetDomainSessionId() {
-        Subject subject = Subject.builder().build();
+        Subject subject = new Subject(new SubjectConfiguration());
         subject.setDomainSessionId("sessionid");
         assertEquals("sessionid", subject.getSubject().get("sid"));
     }
 
     @Test
     public void testGetSubject() {
-        Subject subject = Subject.builder().build();
+        Subject subject = new Subject(new SubjectConfiguration());
         Map<String, String> expected = new HashMap<>();
         subject.setTimezone("America/Toronto");
         subject.setUserId("user1");
@@ -114,26 +114,15 @@ public class SubjectTest {
     }
 
     @Test
-    public void testCreateWithBuilder() {
-        Subject subject = Subject.builder()
-                .domainSessionId("domain session ID")
-                .viewPort(123, 456)
-                .language("en")
-                .build();
-
-        assertEquals("domain session ID", subject.getSubject().get("sid"));
-        assertEquals("123x456", subject.getSubject().get("vp"));
-        assertEquals("en", subject.getSubject().get("lang"));
-    }
-
-    @Test
     public void testCreateFromConfig() {
         SubjectConfiguration subjectConfig = new SubjectConfiguration()
                 .ipAddress("xxx.000.xxx.111")
+                .viewPort(123, 456)
                 .useragent("Mac OS");
         Subject subject = new Subject(subjectConfig);
 
         assertEquals("xxx.000.xxx.111", subject.getSubject().get("ip"));
+        assertEquals("123x456", subject.getSubject().get("vp"));
         assertEquals("Mac OS", subject.getSubject().get("ua"));
     }
 }

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -16,7 +16,6 @@ import java.util.*;
 import static java.util.Collections.singletonList;
 
 import com.snowplowanalytics.snowplow.tracker.configuration.NetworkConfiguration;
-import com.snowplowanalytics.snowplow.tracker.configuration.SubjectConfiguration;
 import com.snowplowanalytics.snowplow.tracker.configuration.TrackerConfiguration;
 import com.snowplowanalytics.snowplow.tracker.emitter.BatchEmitter;
 import org.junit.Before;

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -58,7 +58,7 @@ public class TrackerTest {
     public void setUp() {
         mockEmitter = new MockEmitter();
         TrackerConfiguration trackerConfig = new TrackerConfiguration("AF003", "cloudfront").base64Encoded(false);
-        tracker = new Tracker(trackerConfig, mockEmitter, new Subject(new SubjectConfiguration()));
+        tracker = new Tracker(trackerConfig, mockEmitter, new Subject());
         tracker.getSubject().setTimezone("Etc/UTC");
         contexts = singletonList(new SelfDescribingJson("schema", Collections.singletonMap("foo", "bar")));
     }
@@ -520,7 +520,7 @@ public class TrackerTest {
     @Test
     public void testTrackTimingWithSubject() throws InterruptedException {
         // Make Subject
-        Subject s1 = new Subject(new SubjectConfiguration());
+        Subject s1 = new Subject();
         s1.setIpAddress("127.0.0.1");
         s1.setTimezone("Etc/UTC");
 
@@ -590,11 +590,11 @@ public class TrackerTest {
         // Subject objects always have timezone set
         TimeZone.setDefault(TimeZone.getTimeZone("Etc/UTC"));
 
-        Subject s1 = new Subject(new SubjectConfiguration());
+        Subject s1 = new Subject();
         s1.setLanguage("EN");
         Tracker tracker = new Tracker(new TrackerConfiguration("AF003", "cloudfront"), mockEmitter, s1);
 
-        Subject s2 = new Subject(new SubjectConfiguration());
+        Subject s2 = new Subject();
         s2.setColorDepth(24);
         tracker.setSubject(s2);
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -102,7 +102,7 @@ public class TrackerTest {
             public List<TrackerPayload> getBuffer() { return null; }
         }
         FailingMockEmitter failingMockEmitter = new FailingMockEmitter();
-        tracker = new Tracker("AF003", "cloudfront", failingMockEmitter);
+        tracker = new Tracker(new TrackerConfiguration("AF003", "cloudfront"), failingMockEmitter);
 
         List<String> result = tracker.track(SelfDescribing.builder()
                 .eventData(new SelfDescribingJson(
@@ -572,7 +572,7 @@ public class TrackerTest {
 
     @Test
     public void testGetTrackerVersion() {
-        Tracker tracker = new Tracker("namespace", "an-app-id", mockEmitter);
+        Tracker tracker = new Tracker(new TrackerConfiguration("namespace", "an-app-id"), mockEmitter);
         assertEquals("java-0.12.2", tracker.getTrackerVersion());
     }
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/http/HttpClientAdapterTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/http/HttpClientAdapterTest.java
@@ -50,10 +50,7 @@ public class HttpClientAdapterTest {
                 {new HttpClientAdapterProvider() {
                     @Override
                     public HttpClientAdapter provide(String url) {
-                        return ApacheHttpClientAdapter.builder()
-                                .url(url)
-                                .httpClient(HttpClients.createDefault())
-                                .build();
+                        return new ApacheHttpClientAdapter(url, HttpClients.createDefault());
                     }
                 }},
                 {new HttpClientAdapterProvider() {
@@ -64,10 +61,7 @@ public class HttpClientAdapterTest {
                             .readTimeout(1, TimeUnit.SECONDS)
                             .writeTimeout(1, TimeUnit.SECONDS)
                             .build();
-                        return OkHttpClientAdapter.builder()
-                                .url(url)
-                                .httpClient(httpClient)
-                                .build();
+                        return new OkHttpClientAdapter(url, httpClient);
                     }
                 }
             }
@@ -138,10 +132,7 @@ public class HttpClientAdapterTest {
                 .writeTimeout(1, TimeUnit.SECONDS)
                 .cookieJar(new CollectorCookieJar())
                 .build();
-        adapter = OkHttpClientAdapter.builder()
-                .url(mockWebServer.url("/").toString())
-                .httpClient(httpClient)
-                .build();
+        adapter = new OkHttpClientAdapter(mockWebServer.url("/").toString(), httpClient);
 
         mockWebServer.enqueue(new MockResponse().addHeader("Set-Cookie", "sp=test"));
 


### PR DESCRIPTION
This PR improves the API by deprecating the Builder classes in Tracker, BatchEmitter, Subject and the HttpClientAdapter classes (AbstractHttpClientAdapter, OkHttpClientAdapter, ApacheHttpClientAdapter).

The AbstractHttpClientAdapter class only had one parameter, with another parameter in the child classes: the Builder classes were only present for consistency. New constructors have been added. HttpClientAdapters aren't directly made via Configuration classes.

The Builders have been deprecated, not removed, so this is not a breaking change.

NB Builder methods are still used in the AbstractEvent and other Event classes.