### PR TITLE
Add close() to Emitter interface and Tracker

### DIFF
--- a/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
+++ b/examples/simple-console/src/main/java/com/snowplowanalytics/Main.java
@@ -77,6 +77,7 @@ public class Main {
             .subject(eventSubject)
             .build();
         
+        // EcommerceTransactions will be deprecated soon: we advise using SelfDescribing events instead
         // EcommerceTransactionItems are tracked as part of an EcommerceTransaction event
         // They are processed into separate events during the `track()` call
         EcommerceTransactionItem item = EcommerceTransactionItem.builder()
@@ -151,8 +152,7 @@ public class Main {
         tracker.track(structured);
 
         // Will close all threads and force send remaining events
-        BatchEmitter emitter = (BatchEmitter) tracker.getEmitter();
-        emitter.close();
+        tracker.close();
         Thread.sleep(5000);
 
         System.out.println("Tracked 7 events");

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -356,4 +356,14 @@ public class Tracker {
         }
     }
 
+    /**
+     * Attempts to send all remaining events, then shuts down the Emitter so that no more events can be sent.
+     * This method calls the Emitter.close() method. For the default BatchEmitter,
+     * this stops the ScheduledExecutorService and the thread pool (non-daemon threads).
+     * There is no way to restart the Emitter after calling close().
+     */
+    public void close() {
+        emitter.close();
+    }
+
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/Emitter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/emitter/Emitter.java
@@ -57,4 +57,9 @@ public interface Emitter {
      * @return the buffer events
      */
     List<TrackerPayload> getBuffer();
+
+    /**
+     * Safely shuts down the Emitter.
+     */
+    void close();
 }

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -47,6 +47,8 @@ public class TrackerTest {
         public int getBatchSize() { return 0; }
         @Override
         public List<TrackerPayload> getBuffer() { return null; }
+        @Override
+        public void close() {}
     }
 
     MockEmitter mockEmitter;
@@ -99,6 +101,8 @@ public class TrackerTest {
             public int getBatchSize() { return 0; }
             @Override
             public List<TrackerPayload> getBuffer() { return null; }
+            @Override
+            public void close() {}
         }
         FailingMockEmitter failingMockEmitter = new FailingMockEmitter();
         tracker = new Tracker(new TrackerConfiguration("AF003", "cloudfront"), failingMockEmitter);


### PR DESCRIPTION
Improves the API for stopping the tracker threadpool.