### PR TITLE
Update to Apache Http Client to v5 (close #364)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,8 +62,7 @@ dependencies {
     api 'commons-net:commons-net:3.6'
 
     // Apache HTTP
-    apachehttpSupportApi 'org.apache.httpcomponents:httpclient:4.5.13'
-    apachehttpSupportApi 'org.apache.httpcomponents:httpasyncclient:4.1.5'
+    apachehttpSupportApi 'org.apache.httpcomponents.client5:httpclient5:5.3'
 
     // Square OK HTTP
     okhttpSupportApi 'com.squareup.okhttp3:okhttp:4.9.3'

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/ApacheHttpClientAdapter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/ApacheHttpClientAdapter.java
@@ -12,12 +12,11 @@
  */
 package com.snowplowanalytics.snowplow.tracker.http;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -117,9 +116,9 @@ public class ApacheHttpClientAdapter extends AbstractHttpClientAdapter {
     public int doGet(String url) {
         try {
             HttpGet httpGet = new HttpGet(url);
-            HttpResponse httpResponse = httpClient.execute(httpGet);
-            httpGet.releaseConnection();
-            return httpResponse.getStatusLine().getStatusCode();
+            return httpClient.execute(httpGet, response -> {
+                return response.getCode();
+            });
         } catch (Exception e) {
             LOGGER.error("ApacheHttpClient GET Request failed: {}", e.getMessage());
             return -1;
@@ -140,9 +139,9 @@ public class ApacheHttpClientAdapter extends AbstractHttpClientAdapter {
             httpPost.addHeader("Content-Type", Constants.POST_CONTENT_TYPE);
             StringEntity params = new StringEntity(payload, ContentType.APPLICATION_JSON);
             httpPost.setEntity(params);
-            HttpResponse httpResponse = httpClient.execute(httpPost);
-            httpPost.releaseConnection();
-            return httpResponse.getStatusLine().getStatusCode();
+            return httpClient.execute(httpPost, response -> {
+                return response.getCode();
+            });
         } catch (Exception e) {
             LOGGER.error("ApacheHttpClient POST Request failed: {}", e.getMessage());
             return -1;

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/http/HttpClientAdapterTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/http/HttpClientAdapterTest.java
@@ -23,7 +23,7 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
-import org.apache.http.impl.client.HttpClients;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
 
 import org.junit.Assert;
 import org.junit.Test;


### PR DESCRIPTION
Issue #364 

Updates the Apache HTTP client version from 4 to 5.

Unfortunately this is a breaking change (e.g., the `CloseableHttpClient` that we accept in the adapter now comes from a different package), so we'll need to make a v2 release.