### PR TITLE
Add okhttp adapter with cookie jar and remove cookie jar from network configuration (close #361)

### DIFF
--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/NetworkConfiguration.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/configuration/NetworkConfiguration.java
@@ -13,14 +13,12 @@
 package com.snowplowanalytics.snowplow.tracker.configuration;
 
 import com.snowplowanalytics.snowplow.tracker.http.HttpClientAdapter;
-import okhttp3.CookieJar;
 
 
 public class NetworkConfiguration {
 
     private HttpClientAdapter httpClientAdapter = null; // Optional
     private String collectorUrl = null; // Required if not specifying a httpClientAdapter
-    private CookieJar cookieJar = null; // Optional
 
     // Getters and Setters
 
@@ -38,14 +36,6 @@ public class NetworkConfiguration {
      */
     public String getCollectorUrl() {
         return collectorUrl;
-    }
-
-    /**
-     * Returns the OkHttp CookieJar used for persisting cookies.
-     * @return CookieJar object
-     */
-    public CookieJar getCookieJar() {
-        return cookieJar;
     }
 
     // Constructors
@@ -92,18 +82,6 @@ public class NetworkConfiguration {
      */
     public NetworkConfiguration collectorUrl(String collectorUrl) {
         this.collectorUrl = collectorUrl;
-        return this;
-    }
-
-    /**
-     * Adds a custom CookieJar to be used with OkHttpClientAdapters.
-     * Will be ignored if a custom httpClientAdapter is provided.
-     *
-     * @param cookieJar the CookieJar to use
-     * @return itself
-     */
-    public NetworkConfiguration cookieJar(CookieJar cookieJar) {
-        this.cookieJar = cookieJar;
         return this;
     }
 }

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/OkHttpClientAdapter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/OkHttpClientAdapter.java
@@ -45,6 +45,10 @@ public class OkHttpClientAdapter extends AbstractHttpClientAdapter {
         this.httpClient = httpClient;
     }
 
+    public OkHttpClientAdapter(String url) {
+        this(url, new OkHttpClient.Builder().build());
+    }
+
     /**
      * @deprecated Create HttpClientAdapter directly instead
      * @param <T> Builder

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/http/OkHttpClientWithCookieJarAdapter.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/http/OkHttpClientWithCookieJarAdapter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.tracker.http;
+
+// SquareUp
+import okhttp3.*;
+
+/**
+ * A HttpClient built using OkHttp to send events via GET or POST requests.
+ * The adapter is configured to use a CollectorCookieJar to store and send cookies set by the collector.
+ * The cookies are stored in memory.
+ */
+public class OkHttpClientWithCookieJarAdapter extends OkHttpClientAdapter {
+
+    public OkHttpClientWithCookieJarAdapter(String url) {
+        super(url, new OkHttpClient.Builder().cookieJar(new CollectorCookieJar()).build());
+    }
+
+}

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/http/HttpClientAdapterTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/http/HttpClientAdapterTest.java
@@ -145,13 +145,7 @@ public class HttpClientAdapterTest {
 
     @Test
     public void testRequestWithCookies() throws IOException, InterruptedException {
-        OkHttpClient httpClient = new OkHttpClient.Builder()
-                .connectTimeout(1, TimeUnit.SECONDS)
-                .readTimeout(1, TimeUnit.SECONDS)
-                .writeTimeout(1, TimeUnit.SECONDS)
-                .cookieJar(new CollectorCookieJar())
-                .build();
-        adapter = new OkHttpClientAdapter(mockWebServer.url("/").toString(), httpClient);
+        adapter = new OkHttpClientWithCookieJarAdapter(mockWebServer.url("/").toString());
 
         mockWebServer.enqueue(new MockResponse().addHeader("Set-Cookie", "sp=test"));
 


### PR DESCRIPTION
Issue #361

This PR removes references to okhttp3 from the network configuration and batch emitter to allow using the tracker without such a dependency.

In particular, it removes the cookie jar confguration from the network config. In it's place, it adds a `OkHttpClientWithCookieJarAdapter` adapter that is already configured with the cookie jar.