### PR TITLE
Handle DateTime serializing (Fixes #378)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ dependencies {
 
     // Jackson JSON processor
     api 'com.fasterxml.jackson.core:jackson-databind:2.16.1'
+    api 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
     // Testing libraries
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.1'

--- a/src/main/java/com/snowplowanalytics/snowplow/tracker/Utils.java
+++ b/src/main/java/com/snowplowanalytics/snowplow/tracker/Utils.java
@@ -20,6 +20,8 @@ import java.net.URLEncoder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +31,10 @@ import org.slf4j.LoggerFactory;
 public class Utils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Utils.class);
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper
+            = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
 
     // Tracker Utils
 

--- a/src/test/java/com/snowplowanalytics/snowplow/tracker/UtilsTest.java
+++ b/src/test/java/com/snowplowanalytics/snowplow/tracker/UtilsTest.java
@@ -17,6 +17,8 @@ import org.junit.Test;
 
 // Java
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -68,6 +70,14 @@ public class UtilsTest {
         Map<String, Object> payload2 = new LinkedHashMap<>();
         payload2.put("k1", new Object());
         assertEquals("", Utils.mapToJSONString(payload2));
+
+        Map<String, Object> payload3 = new LinkedHashMap<>();
+        payload3.put("k1", LocalDateTime.of(2020, 1, 1, 0, 0));
+        assertEquals("{\"k1\":\"2020-01-01T00:00:00\"}", Utils.mapToJSONString(payload3));
+
+        Map<String, Object> payload4 = new LinkedHashMap<>();
+        payload4.put("k1", LocalDate.of(2020, 1, 1));
+        assertEquals("{\"k1\":\"2020-01-01\"}", Utils.mapToJSONString(payload4));
     }
 
     @Test


### PR DESCRIPTION
Add handling for parsing date and time objects when serialising a Map<K,V> to a JSON String.